### PR TITLE
OBPIH-6915: Add removing stock movement in fieldValidation test

### DIFF
--- a/src/pages/inbound/create/steps/SendStep.ts
+++ b/src/pages/inbound/create/steps/SendStep.ts
@@ -52,6 +52,10 @@ class SendStep extends BasePageModel {
     return this.page.getByRole('button', { name: 'Save and Exit' });
   }
 
+  get acceptConfirmExitDialog() {
+    return this.page.getByRole('button', { name: 'Yes' });
+  }
+
   async isLoaded() {
     await expect(this.originField.textbox).toBeVisible();
     await expect(this.destinationSelect.selectField).toBeVisible();

--- a/src/pages/stockMovementShow/StockMovementShowPage.ts
+++ b/src/pages/stockMovementShow/StockMovementShowPage.ts
@@ -83,6 +83,11 @@ class StockMovementShowPage extends BasePageModel {
   get errorMessage() {
     return this.page.locator('div.error');
   }
+
+  async clickDeleteShipment() {
+    this.page.once('dialog', (dialog) => dialog.accept());
+    await this.deleteButton.click();
+  }
 }
 
 export default StockMovementShowPage;

--- a/src/tests/inbound/createInbound/fieldValidation.test.ts
+++ b/src/tests/inbound/createInbound/fieldValidation.test.ts
@@ -66,7 +66,7 @@ test.afterEach(async ({ stockMovementService }) => {
 
 test('Create Inbound stock movement field validations', async ({
   createInboundPage,
-  stockMovementShowPage
+  stockMovementShowPage,
 }) => {
   await test.step('Go to create inbound page', async () => {
     await createInboundPage.goToPage();
@@ -132,7 +132,6 @@ test('Create Inbound stock movement field validations', async ({
   await test.step('Go to next step (Create -> Add Items)', async () => {
     await createInboundPage.nextButton.click();
   });
-
 
   await test.step('Assert next button should be disabled on empty table (Add Items)', async () => {
     await expect(createInboundPage.nextButton).toBeDisabled();
@@ -237,8 +236,5 @@ test('Create Inbound stock movement field validations', async ({
     await stockMovementShowPage.waitForUrl();
     await stockMovementShowPage.isLoaded();
     await stockMovementShowPage.clickDeleteShipment();
-  }); 
-
-
-
+  });
 });

--- a/src/tests/inbound/createInbound/fieldValidation.test.ts
+++ b/src/tests/inbound/createInbound/fieldValidation.test.ts
@@ -66,6 +66,7 @@ test.afterEach(async ({ stockMovementService }) => {
 
 test('Create Inbound stock movement field validations', async ({
   createInboundPage,
+  stockMovementShowPage
 }) => {
   await test.step('Go to create inbound page', async () => {
     await createInboundPage.goToPage();
@@ -131,6 +132,7 @@ test('Create Inbound stock movement field validations', async ({
   await test.step('Go to next step (Create -> Add Items)', async () => {
     await createInboundPage.nextButton.click();
   });
+
 
   await test.step('Assert next button should be disabled on empty table (Add Items)', async () => {
     await expect(createInboundPage.nextButton).toBeDisabled();
@@ -227,4 +229,16 @@ test('Create Inbound stock movement field validations', async ({
       'Please verify timeline. Delivery date cannot be before Ship date.'
     );
   });
+
+  await test.step('Save and exit and delete shipment', async () => {
+    await createInboundPage.sendStep.saveAndExitButton.click();
+    await createInboundPage.sendStep.validationPopup.assertPopupVisible();
+    await createInboundPage.sendStep.acceptConfirmExitDialog.click();
+    await stockMovementShowPage.waitForUrl();
+    await stockMovementShowPage.isLoaded();
+    await stockMovementShowPage.clickDeleteShipment();
+  }); 
+
+
+
 });

--- a/src/tests/inbound/listPage/updatedByFilter.test.ts
+++ b/src/tests/inbound/listPage/updatedByFilter.test.ts
@@ -29,7 +29,7 @@ test.describe('Use "Updated By" filter', () => {
     await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
   });
 
-  test.skip('Only show stock movements updated by filtered user', async ({
+  test('Only show stock movements updated by filtered user', async ({
     altUserContext,
     inboundListPage,
     mainProductService,

--- a/src/tests/receiving/validationsOnEditAndReceive.test.ts
+++ b/src/tests/receiving/validationsOnEditAndReceive.test.ts
@@ -160,6 +160,11 @@ test.describe('Validations on edit and receive inbound stock movement', () => {
         'Cannot edit received shipment'
       );
     });
+
+    await test.step('Rollback shipment received in 2 receipts', async () => {
+      await stockMovementShowPage.isLoaded();
+      await stockMovementShowPage.rollbackLastReceiptButton.click();
+    });
   });
 
   test('Assert unable to receive already received inbounds', async ({


### PR DESCRIPTION
It turned out that there are 2 shipments created in this test and only the one created in beforeEach was deleted. I added deleting the shipment which is created within the test.
I am not sure if we need beforeEach and afterEach in this test at all as this shipment is not used but I didn't want to delete it without consulting it.  