### PR TITLE
OBPIH-6957  add assert recipient not editable test

### DIFF
--- a/src/api/StockMovementService.ts
+++ b/src/api/StockMovementService.ts
@@ -136,6 +136,7 @@ class StockMovementService extends BaseServiceModel {
           : undefined,
         palletName: it?.palletName,
         boxName: it?.boxName,
+        recipient: it.recipientId ? { id: it.recipientId } : undefined,
       })),
     });
     await this.updateStatusStockMovement(id, { status: 'CHECKING' });

--- a/src/pages/receiving/components/ReceivingTable.ts
+++ b/src/pages/receiving/components/ReceivingTable.ts
@@ -73,6 +73,10 @@ class Row extends BasePageModel {
       .locator('.css-5ih5ya-group react-select__group-heading')
       .getByText(zoneLocation, { exact: true });
   }
+
+  get recipientField() {
+    return this.row.getByRole('cell', { name: 'Recipient' });
+  }
 }
 
 export default ReceivingTable;

--- a/src/pages/receiving/steps/CheckStep.ts
+++ b/src/pages/receiving/steps/CheckStep.ts
@@ -47,6 +47,10 @@ class CheckStep extends BasePageModel {
       .locator('.s-alert-box-inner')
       .getByText('Must occur on or after Actual Shipping Date');
   }
+
+  get backToEditButton() {
+    return this.page.getByRole('button', { name: 'Back to edit' });
+  }
 }
 
 export default CheckStep;

--- a/src/tests/receiving/assertBinLocationField.test.ts
+++ b/src/tests/receiving/assertBinLocationField.test.ts
@@ -69,12 +69,10 @@ test.describe('Assert bin location not clearable', () => {
     });
 
     await test.step('Assert bin location cant be cleared', async () => {
-      await expect(
+            await expect(
         receivingPage.receivingStep.table
           .row(1)
-          .binLocationSelect.locator(
-            '[class="css-16pqwjk-indicatorContainer react-select__indicator react-select__clear-indicator"]'
-          )
+          .binLocationSelect.locator('.react-select__clear-indicator')
       ).toBeHidden();
     });
 
@@ -103,16 +101,12 @@ test.describe('Assert bin location not clearable', () => {
       await expect(
         receivingPage.receivingStep.table
           .row(1)
-          .binLocationSelect.locator(
-            '[class="css-16pqwjk-indicatorContainer react-select__indicator react-select__clear-indicator"]'
-          )
+          .binLocationSelect.locator('.react-select__clear-indicator')
       ).toBeHidden();
       await expect(
         receivingPage.receivingStep.table
           .row(2)
-          .binLocationSelect.locator(
-            '[class="css-16pqwjk-indicatorContainer react-select__indicator react-select__clear-indicator"]'
-          )
+          .binLocationSelect.locator('.react-select__clear-indicator')
       ).toBeHidden();
     });
   });

--- a/src/tests/receiving/assertBinLocationField.test.ts
+++ b/src/tests/receiving/assertBinLocationField.test.ts
@@ -1,0 +1,119 @@
+import AppConfig from '@/config/AppConfig';
+import { ShipmentType } from '@/constants/ShipmentType';
+import { expect, test } from '@/fixtures/fixtures';
+import { StockMovementResponse } from '@/types';
+
+test.describe('Assert bin location not clearable', () => {
+  let STOCK_MOVEMENT: StockMovementResponse;
+
+  test.beforeEach(
+    async ({
+      supplierLocationService,
+      stockMovementService,
+      fourthProductService,
+    }) => {
+      const supplierLocation = await supplierLocationService.getLocation();
+      const PRODUCT_FOUR = await fourthProductService.getProduct();
+
+      STOCK_MOVEMENT = await stockMovementService.createInbound({
+        originId: supplierLocation.id,
+      });
+
+      await stockMovementService.addItemsToInboundStockMovement(
+        STOCK_MOVEMENT.id,
+        [
+          {
+            productId: PRODUCT_FOUR.id,
+            quantity: 10,
+          },
+        ]
+      );
+
+      await stockMovementService.sendInboundStockMovement(STOCK_MOVEMENT.id, {
+        shipmentType: ShipmentType.AIR,
+      });
+    }
+  );
+
+  test.afterEach(async ({ stockMovementShowPage, stockMovementService }) => {
+    await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+    const isRollbackLastReceiptButtonVisible =
+      await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
+    const isRollbackButtonVisible =
+      await stockMovementShowPage.rollbackButton.isVisible();
+
+    // due to failed test, shipment might not be received which will not show the button
+    if (isRollbackLastReceiptButtonVisible) {
+      await stockMovementShowPage.rollbackLastReceiptButton.click();
+    }
+
+    if (isRollbackButtonVisible) {
+      await stockMovementShowPage.rollbackButton.click();
+    }
+
+    await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+  });
+
+  test('Assert bin location not clearable', async ({
+    stockMovementShowPage,
+    receivingPage,
+  }) => {
+    await test.step('Go to stock movement show page', async () => {
+      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+      await stockMovementShowPage.isLoaded();
+    });
+
+    await test.step('Go to shipment receiving page', async () => {
+      await stockMovementShowPage.receiveButton.click();
+      await receivingPage.receivingStep.isLoaded();
+    });
+
+    await test.step('Assert bin location cant be cleared', async () => {
+      await expect(
+        receivingPage.receivingStep.table
+          .row(1)
+          .binLocationSelect.locator(
+            '[class="css-16pqwjk-indicatorContainer react-select__indicator react-select__clear-indicator"]'
+          )
+      ).toBeHidden();
+    });
+
+    await test.step('Split lines', async () => {
+      await receivingPage.receivingStep.table.row(1).editButton.click();
+      await receivingPage.receivingStep.editModal.isLoaded();
+      await receivingPage.receivingStep.editModal.addLineButton.click();
+      await receivingPage.receivingStep.editModal.table
+        .row(1)
+        .quantityShippedField.numberbox.fill('5');
+      await receivingPage.receivingStep.editModal.table
+        .row(0)
+        .quantityShippedField.numberbox.fill('5');
+      await receivingPage.receivingStep.editModal.saveButton.click();
+    });
+
+    await test.step('Assertbin location field content after split linw', async () => {
+      const receivingBin =
+        AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
+      await expect(
+        receivingPage.receivingStep.table.row(1).binLocationSelect
+      ).toHaveText(receivingBin);
+      await expect(
+        receivingPage.receivingStep.table.row(2).binLocationSelect
+      ).toHaveText(receivingBin);
+      await expect(
+        receivingPage.receivingStep.table
+          .row(1)
+          .binLocationSelect.locator(
+            '[class="css-16pqwjk-indicatorContainer react-select__indicator react-select__clear-indicator"]'
+          )
+      ).toBeHidden();
+      await expect(
+        receivingPage.receivingStep.table
+          .row(2)
+          .binLocationSelect.locator(
+            '[class="css-16pqwjk-indicatorContainer react-select__indicator react-select__clear-indicator"]'
+          )
+      ).toBeHidden();
+    });
+  });
+});

--- a/src/tests/receiving/assertRecipientField.test.ts
+++ b/src/tests/receiving/assertRecipientField.test.ts
@@ -1,0 +1,167 @@
+import { ShipmentType } from '@/constants/ShipmentType';
+import { expect, test } from '@/fixtures/fixtures';
+import { StockMovementResponse } from '@/types';
+
+test.describe('Assert recipient field when receive', () => {
+  let STOCK_MOVEMENT: StockMovementResponse;
+
+  test.beforeEach(
+    async ({
+      supplierLocationService,
+      stockMovementService,
+      fourthProductService,
+      fifthProductService,
+      mainUserService,
+    }) => {
+      const supplierLocation = await supplierLocationService.getLocation();
+      const PRODUCT_FOUR = await fourthProductService.getProduct();
+      const PRODUCT_FIVE = await fifthProductService.getProduct();
+      const USER = await mainUserService.getUser();
+
+      STOCK_MOVEMENT = await stockMovementService.createInbound({
+        originId: supplierLocation.id,
+      });
+
+      await stockMovementService.addItemsToInboundStockMovement(
+        STOCK_MOVEMENT.id,
+        [
+          {
+            productId: PRODUCT_FOUR.id,
+            quantity: 10,
+            recipientId: USER.id,
+          },
+          {
+            productId: PRODUCT_FIVE.id,
+            quantity: 10,
+          },
+        ]
+      );
+
+      await stockMovementService.sendInboundStockMovement(STOCK_MOVEMENT.id, {
+        shipmentType: ShipmentType.AIR,
+      });
+    }
+  );
+
+  test.afterEach(async ({ stockMovementShowPage, stockMovementService }) => {
+    await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+    const isRollbackLastReceiptButtonVisible =
+      await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
+    const isRollbackButtonVisible =
+      await stockMovementShowPage.rollbackButton.isVisible();
+
+    // due to failed test, shipment might not be received which will not show the button
+    if (isRollbackLastReceiptButtonVisible) {
+      await stockMovementShowPage.rollbackLastReceiptButton.click();
+    }
+
+    if (isRollbackButtonVisible) {
+      await stockMovementShowPage.rollbackButton.click();
+    }
+
+    await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+  });
+
+  test('Assert recipient field filled and disabled', async ({
+    stockMovementShowPage,
+    receivingPage,
+    mainUserService,
+  }) => {
+    await test.step('Go to stock movement show page', async () => {
+      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+      await stockMovementShowPage.isLoaded();
+    });
+
+    await test.step('Go to shipment receiving page', async () => {
+      await stockMovementShowPage.receiveButton.click();
+      await receivingPage.receivingStep.isLoaded();
+    });
+
+    await test.step('Assert recipient field disabled and filled', async () => {
+      const USER = await mainUserService.getUser();
+      await expect(
+        receivingPage.receivingStep.table.getCellValue(1, 'Recipient')
+      ).toBeEmpty();
+      await receivingPage.receivingStep.table
+        .row(1)
+        .recipientField.isDisabled();
+      await expect(
+        receivingPage.receivingStep.table.getCellValue(2, 'Recipient')
+      ).toHaveText(USER.name);
+      await receivingPage.receivingStep.table.row(2).recipientField.click();
+      await receivingPage.receivingStep.table
+        .row(2)
+        .recipientField.getByTestId('custom-select-dropdown-menu')
+        .isHidden();
+    });
+
+    await test.step('Fill partial qty for items', async () => {
+      await receivingPage.receivingStep.table
+        .row(1)
+        .receivingNowField.textbox.fill('5');
+      await receivingPage.receivingStep.table
+        .row(2)
+        .receivingNowField.textbox.fill('5');
+      await receivingPage.nextButton.click();
+      await receivingPage.checkStep.isLoaded();
+    });
+
+    await test.step('Fill partial qty for items', async () => {
+      const USER = await mainUserService.getUser();
+      await receivingPage.checkStep.isLoaded();
+      await expect(
+        receivingPage.checkStep.table.getCellValue(1, 'Recipient')
+      ).toBeEmpty();
+      await expect(
+        receivingPage.checkStep.table.getCellValue(2, 'Recipient')
+      ).toHaveText(USER.name);
+    });
+
+    await test.step('Go backward and assert recipient field', async () => {
+      const USER = await mainUserService.getUser();
+      await receivingPage.checkStep.backToEditButton.click();
+      await receivingPage.receivingStep.isLoaded();
+      await expect(
+        receivingPage.receivingStep.table.getCellValue(1, 'Recipient')
+      ).toBeEmpty();
+      await receivingPage.receivingStep.table
+        .row(1)
+        .recipientField.isDisabled();
+      await expect(
+        receivingPage.receivingStep.table.getCellValue(2, 'Recipient')
+      ).toHaveText(USER.name);
+      await receivingPage.receivingStep.table.row(2).recipientField.click();
+      await receivingPage.receivingStep.table
+        .row(2)
+        .recipientField.getByTestId('custom-select-dropdown-menu')
+        .isHidden();
+    });
+
+    await test.step('Finish 1st receipt', async () => {
+      await receivingPage.nextButton.click();
+      await receivingPage.checkStep.isLoaded();
+      await receivingPage.checkStep.receiveShipmentButton.click();
+      await stockMovementShowPage.isLoaded();
+    });
+
+    await test.step('Start 2nd receipt and assert recipient field', async () => {
+      const USER = await mainUserService.getUser();
+      await stockMovementShowPage.receiveButton.click();
+      await receivingPage.receivingStep.isLoaded();
+      await expect(
+        receivingPage.receivingStep.table.getCellValue(1, 'Recipient')
+      ).toBeEmpty();
+      await receivingPage.receivingStep.table
+        .row(1)
+        .recipientField.isDisabled();
+      await expect(
+        receivingPage.receivingStep.table.getCellValue(2, 'Recipient')
+      ).toHaveText(USER.name);
+      await receivingPage.receivingStep.table.row(2).recipientField.click();
+      await receivingPage.receivingStep.table
+        .row(2)
+        .recipientField.getByTestId('custom-select-dropdown-menu')
+        .isHidden();
+    });
+  });
+});

--- a/src/tests/receiving/editBinLocationWhenReceive.test.ts
+++ b/src/tests/receiving/editBinLocationWhenReceive.test.ts
@@ -5,7 +5,7 @@ import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 test.describe('Edit Bin Location when receive inbound stock movement', () => {
   test.describe.configure({ timeout: 60000 });
-  //timeout has been added for this test to make sure that the content on bin location tab will load as it can include a lot of data 
+  //timeout has been added for this test to make sure that the content on bin location tab will load as it can include a lot of data
   let STOCK_MOVEMENT: StockMovementResponse;
   const uniqueIdentifier = new UniqueIdentifier();
   const binLocationName = uniqueIdentifier.generateUniqueString('bin');
@@ -160,7 +160,7 @@ test.describe('Edit Bin Location when receive inbound stock movement', () => {
 
 test.describe('Edit Bin Location to bin with zone when receive inbound stock movement', () => {
   test.describe.configure({ timeout: 60000 });
-  //timeout has been added for this test to make sure that the content on bin location tab will load as it can include a lot of data 
+  //timeout has been added for this test to make sure that the content on bin location tab will load as it can include a lot of data
   let STOCK_MOVEMENT: StockMovementResponse;
   const uniqueIdentifier = new UniqueIdentifier();
   const binLocationName = uniqueIdentifier.generateUniqueString('bin');
@@ -360,6 +360,155 @@ test.describe('Edit Bin Location to bin with zone when receive inbound stock mov
       await expect(
         productShowPage.inStockTabSection.row(2).binLocation
       ).toHaveText(binLocationName);
+    });
+  });
+});
+
+test.describe('Edit Bin Location when receive for all lines', () => {
+  test.describe.configure({ timeout: 60000 });
+  //timeout has been added for this test to make sure that the content on bin location tab will load as it can include a lot of data
+  let STOCK_MOVEMENT: StockMovementResponse;
+  const uniqueIdentifier = new UniqueIdentifier();
+  const binLocationName = uniqueIdentifier.generateUniqueString('bin');
+
+  test.beforeEach(
+    async ({
+      supplierLocationService,
+      mainLocationService,
+      stockMovementService,
+      mainProductService,
+      otherProductService,
+      page,
+      locationListPage,
+      createLocationPage,
+    }) => {
+      const supplierLocation = await supplierLocationService.getLocation();
+      const mainLocation = await mainLocationService.getLocation();
+      const PRODUCT_ONE = await mainProductService.getProduct();
+      const PRODUCT_TWO = await otherProductService.getProduct();
+
+      STOCK_MOVEMENT = await stockMovementService.createInbound({
+        originId: supplierLocation.id,
+      });
+
+      await stockMovementService.addItemsToInboundStockMovement(
+        STOCK_MOVEMENT.id,
+        [
+          { productId: PRODUCT_ONE.id, quantity: 20 },
+          { productId: PRODUCT_TWO.id, quantity: 10 },
+        ]
+      );
+
+      await stockMovementService.sendInboundStockMovement(STOCK_MOVEMENT.id, {
+        shipmentType: ShipmentType.AIR,
+      });
+
+      await test.step('Create bin location for location', async () => {
+        await page.goto('./location/list');
+        await locationListPage.searchByLocationNameField.fill(
+          mainLocation.name
+        );
+        await locationListPage.findButton.click();
+        await expect(
+          locationListPage.getLocationEditButton(mainLocation.name)
+        ).toBeVisible();
+        await locationListPage.getLocationEditButton(mainLocation.name).click();
+        await createLocationPage.binLocationTab.click();
+        await createLocationPage.binLocationTabSection.isLoaded();
+        await createLocationPage.binLocationTabSection.addBinLocationButton.click();
+        await createLocationPage.binLocationTabSection.addBinLocationDialog.binLocationNameField.fill(
+          binLocationName
+        );
+        await createLocationPage.binLocationTabSection.addBinLocationDialog.saveButton.click();
+      });
+    }
+  );
+
+  test.afterEach(
+    async ({
+      stockMovementShowPage,
+      stockMovementService,
+      page,
+      locationListPage,
+      mainLocationService,
+      createLocationPage,
+    }) => {
+      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+      await stockMovementShowPage.rollbackLastReceiptButton.click();
+      await stockMovementShowPage.rollbackButton.click();
+      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+
+      await test.step('Delete created bin location', async () => {
+        const mainLocation = await mainLocationService.getLocation();
+        await page.goto('./location/list');
+        await locationListPage.searchByLocationNameField.fill(
+          mainLocation.name
+        );
+        await locationListPage.findButton.click();
+        await expect(
+          locationListPage.getLocationEditButton(mainLocation.name)
+        ).toBeVisible();
+        await locationListPage.getLocationEditButton(mainLocation.name).click();
+        await createLocationPage.binLocationTab.click();
+        await createLocationPage.binLocationTabSection.isLoaded();
+        await createLocationPage.binLocationTabSection.searchField.fill(
+          binLocationName
+        );
+        await createLocationPage.binLocationTabSection.searchField.press(
+          'Enter'
+        );
+        await createLocationPage.binLocationTabSection.isLoaded();
+        await createLocationPage.binLocationTabSection.deleteBinButton.click();
+        await createLocationPage.binLocationTabSection.isLoaded();
+      });
+    }
+  );
+
+  test('Edit Bin location when receive for all lines', async ({
+    stockMovementShowPage,
+    receivingPage,
+  }) => {
+    await test.step('Go to stock movement show page', async () => {
+      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+      await stockMovementShowPage.isLoaded();
+    });
+
+    await test.step('Go to shipment receiving page', async () => {
+      await stockMovementShowPage.receiveButton.click();
+      await receivingPage.receivingStep.isLoaded();
+    });
+
+    await test.step('Edit bin when receive item', async () => {
+      await receivingPage.receivingStep.isLoaded();
+      await receivingPage.receivingStep.table.row(0).binLocationSelect.click();
+      await receivingPage.receivingStep.table
+        .row(0)
+        .getBinLocation(binLocationName)
+        .click();
+      await expect(
+        receivingPage.receivingStep.table.row(1).binLocationSelect
+      ).toHaveText(binLocationName);
+      await expect(
+        receivingPage.receivingStep.table.row(2).binLocationSelect
+      ).toHaveText(binLocationName);
+    });
+
+    await test.step('Autofill qty and go to check page', async () => {
+      await receivingPage.receivingStep.autofillQuantitiesButton.click();
+      await receivingPage.nextButton.click();
+      await receivingPage.checkStep.isLoaded();
+    });
+
+    await test.step('Finish receipt of item', async () => {
+      await receivingPage.checkStep.isLoaded();
+      await expect(
+        receivingPage.checkStep.table.getCellValue(1, 'Bin Location')
+      ).toHaveText(binLocationName);
+      await expect(
+        receivingPage.checkStep.table.getCellValue(2, 'Bin Location')
+      ).toHaveText(binLocationName);
+      await receivingPage.checkStep.receiveShipmentButton.click();
+      await stockMovementShowPage.isLoaded();
     });
   });
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -247,6 +247,7 @@ type LineItemsPayload = {
   expirationDate?: Date;
   palletName?: string;
   boxName?: string;
+  recipientId?: string;
 }[];
 
 type SendInboundPayload = {


### PR DESCRIPTION
Added test for asserting recipient field is not editable in the middle of receipt, added recipient field to StockMovementService. I also added test for asserting bin location is not clearable field and to edit bin locations for all lines when receiving. 