### PR TITLE
OBPIH-7234 sort by alphabetical order and remain inputs

### DIFF
--- a/src/components/AlertPopup.ts
+++ b/src/components/AlertPopup.ts
@@ -24,6 +24,10 @@ class AlertPopup extends BasePageModel {
     return this.dialog.getByRole('button', { name: this.cancelLabel });
   }
 
+  get yesButton() {
+    return this.dialog.getByRole('button', { name: 'Yes' });
+  }
+
   async assertPopupVisible() {
     await expect(this.dialog).toBeVisible();
   }

--- a/src/config/AppConfig.ts
+++ b/src/config/AppConfig.ts
@@ -290,7 +290,7 @@ class AppConfig {
       productFive: new ProductConfig({
         id: env.get('PRODUCT_FIVE').asString(),
         key: PRODUCT_KEY.FIVE,
-        name: this.uniqueIdentifier.generateUniqueString('product-five'),
+        name: this.uniqueIdentifier.generateUniqueString('aaproduct-five'),
         quantity: 160,
         required: false,
       }),

--- a/src/config/AppConfig.ts
+++ b/src/config/AppConfig.ts
@@ -290,7 +290,8 @@ class AppConfig {
       productFive: new ProductConfig({
         id: env.get('PRODUCT_FIVE').asString(),
         key: PRODUCT_KEY.FIVE,
-        name: this.uniqueIdentifier.generateUniqueString('aaproduct-five'),
+        name: this.uniqueIdentifier.generateUniqueString('aa-product-five'),
+        //'aa' part was added to improve visibility of ordering products alphabetically
         quantity: 160,
         required: false,
       }),

--- a/src/pages/inbound/create/steps/AddItemsStep.ts
+++ b/src/pages/inbound/create/steps/AddItemsStep.ts
@@ -1,5 +1,6 @@
 import { Page } from '@playwright/test';
 
+import AlertPopup from '@/components/AlertPopup';
 import FileHandler from '@/components/FileHandler';
 import { expect, test } from '@/fixtures/fixtures';
 import BasePageModel from '@/pages/BasePageModel';
@@ -9,11 +10,17 @@ import { CreateInboundAddItemsTableEntity } from '@/types';
 class AddItemsStep extends BasePageModel {
   table: AddItemsTable;
   fileHandler: FileHandler;
+  confirmReloadPopup: AlertPopup;
 
   constructor(page: Page) {
     super(page);
     this.table = new AddItemsTable(page);
     this.fileHandler = new FileHandler(page);
+    this.confirmReloadPopup = new AlertPopup(
+      page,
+      'Confirm refresh',
+      'Are you sure you want to refresh? Your progress since last save will be lost.'
+    );
   }
 
   async isLoaded() {

--- a/src/pages/receiving/steps/ReceivingStep.ts
+++ b/src/pages/receiving/steps/ReceivingStep.ts
@@ -85,10 +85,7 @@ class ReceivingStep extends BasePageModel {
   }
 
   get orderSelect() {
-    return this.page
-      .getByTestId('custom-select-element')
-      .locator('.css-16pqwjk-indicatorContainer')
-      .first();
+    return this.page.getByTestId('custom-select-ordering');
   }
 
   getOrder(order: string) {

--- a/src/pages/receiving/steps/ReceivingStep.ts
+++ b/src/pages/receiving/steps/ReceivingStep.ts
@@ -83,6 +83,20 @@ class ReceivingStep extends BasePageModel {
         'You can only import the Receiving Now and the Comment fields. To make other changes, please use the edit line feature. You can then export and import the template again.'
       );
   }
+
+  get orderSelect() {
+    return this.page
+      .getByTestId('custom-select-element')
+      .locator('.css-16pqwjk-indicatorContainer')
+      .first();
+  }
+
+  getOrder(order: string) {
+    return this.page
+      .getByTestId('custom-select-dropdown-menu')
+      .getByRole('listitem')
+      .getByText(order, { exact: true });
+  }
 }
 
 export default ReceivingStep;

--- a/src/tests/receiving/editBinLocationWhenReceive.test.ts
+++ b/src/tests/receiving/editBinLocationWhenReceive.test.ts
@@ -98,7 +98,6 @@ test.describe('Edit Bin Location when receive inbound stock movement', () => {
         );
         await createLocationPage.binLocationTabSection.isLoaded();
         await createLocationPage.binLocationTabSection.deleteBinButton.click();
-        await createLocationPage.binLocationTabSection.isLoaded();
       });
     }
   );
@@ -279,7 +278,6 @@ test.describe('Edit Bin Location to bin with zone when receive inbound stock mov
         );
         await createLocationPage.binLocationTabSection.isLoaded();
         await createLocationPage.binLocationTabSection.deleteBinButton.click();
-        await createLocationPage.binLocationTabSection.isLoaded();
       });
 
       await test.step('Delete created zone location', async () => {
@@ -459,7 +457,6 @@ test.describe('Edit Bin Location when receive for all lines', () => {
         );
         await createLocationPage.binLocationTabSection.isLoaded();
         await createLocationPage.binLocationTabSection.deleteBinButton.click();
-        await createLocationPage.binLocationTabSection.isLoaded();
       });
     }
   );

--- a/src/tests/receiving/receiveToHoldBin.test.ts
+++ b/src/tests/receiving/receiveToHoldBin.test.ts
@@ -5,7 +5,7 @@ import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 test.describe('Receive item into hold bin', () => {
   test.describe.configure({ timeout: 60000 });
-  //timeout has been added for this test to make sure that the content on bin location tab will load as it can include a lot of data 
+  //timeout has been added for this test to make sure that the content on bin location tab will load as it can include a lot of data
   let STOCK_MOVEMENT: StockMovementResponse;
   const uniqueIdentifier = new UniqueIdentifier();
   const binLocationName = uniqueIdentifier.generateUniqueString('holdbin');
@@ -30,9 +30,7 @@ test.describe('Receive item into hold bin', () => {
 
       await stockMovementService.addItemsToInboundStockMovement(
         STOCK_MOVEMENT.id,
-        [
-          { productId: PRODUCT_ONE.id, quantity: 20 },
-        ]
+        [{ productId: PRODUCT_ONE.id, quantity: 20 }]
       );
 
       await stockMovementService.sendInboundStockMovement(STOCK_MOVEMENT.id, {
@@ -67,10 +65,16 @@ test.describe('Receive item into hold bin', () => {
         await createLocationPage.binLocationTabSection.editBinButton.click();
         await createLocationPage.locationConfigurationTab.click();
         await createLocationPage.locationConfigurationTabSection.useDefaultSettingsCheckbox.uncheck();
-        await createLocationPage.locationConfigurationTabSection.removeSupportedActivitiesButton('Putaway stock').click();
-        await createLocationPage.locationConfigurationTabSection.removeSupportedActivitiesButton('Pick stock').click();
+        await createLocationPage.locationConfigurationTabSection
+          .removeSupportedActivitiesButton('Putaway stock')
+          .click();
+        await createLocationPage.locationConfigurationTabSection
+          .removeSupportedActivitiesButton('Pick stock')
+          .click();
         await createLocationPage.locationConfigurationTabSection.supportedActivitiesSelect.click();
-        await createLocationPage.locationConfigurationTabSection.getSupportedActivitiesOption('Hold stock').click();
+        await createLocationPage.locationConfigurationTabSection
+          .getSupportedActivitiesOption('Hold stock')
+          .click();
         await createLocationPage.locationConfigurationTabSection.saveButton.click();
       });
     }
@@ -111,7 +115,6 @@ test.describe('Receive item into hold bin', () => {
         );
         await createLocationPage.binLocationTabSection.isLoaded();
         await createLocationPage.binLocationTabSection.deleteBinButton.click();
-        await createLocationPage.binLocationTabSection.isLoaded();
       });
     }
   );
@@ -167,8 +170,12 @@ test.describe('Receive item into hold bin', () => {
       await expect(
         productShowPage.inStockTabSection.row(2).binLocation
       ).toHaveText(binLocationName);
-      await expect(productShowPage.inStockTabSection.row(2).row).toHaveAttribute('title', 'This bin has been restricted');
-      await expect(productShowPage.inStockTabSection.row(2).inventoryInformation).toHaveText('Hold');
+      await expect(
+        productShowPage.inStockTabSection.row(2).row
+      ).toHaveAttribute('title', 'This bin has been restricted');
+      await expect(
+        productShowPage.inStockTabSection.row(2).inventoryInformation
+      ).toHaveText('Hold');
     });
   });
 });

--- a/src/tests/receiving/sortByAlphabeticalOrderAndRemainInputs.test.ts
+++ b/src/tests/receiving/sortByAlphabeticalOrderAndRemainInputs.test.ts
@@ -1,0 +1,157 @@
+import { expect, test } from '@/fixtures/fixtures';
+import { StockMovementResponse } from '@/types';
+import { getDateByOffset, getToday } from '@/utils/DateUtils';
+
+test.describe('Apply sorting by alphabetical order and remain inputs', () => {
+  let STOCK_MOVEMENT: StockMovementResponse;
+  const TODAY = getToday();
+  const EXPECTED_DELIVERY_DATE = getDateByOffset(TODAY, 1);
+  const SHIPMENT_TYPE = 'Air';
+
+  test.beforeEach(
+    async ({
+      supplierLocationService,
+      stockMovementService,
+      thirdProductService,
+      fourthProductService,
+    }) => {
+      const supplierLocation = await supplierLocationService.getLocation();
+      const PRODUCT_THREE = await thirdProductService.getProduct();
+      const PRODUCT_FOUR = await fourthProductService.getProduct();
+
+      STOCK_MOVEMENT = await stockMovementService.createInbound({
+        originId: supplierLocation.id,
+      });
+
+      await stockMovementService.addItemsToInboundStockMovement(
+        STOCK_MOVEMENT.id,
+        [
+          { productId: PRODUCT_THREE.id, quantity: 50 },
+          { productId: PRODUCT_FOUR.id, quantity: 200 },
+        ]
+      );
+    }
+  );
+
+  test.afterEach(async ({ stockMovementShowPage, stockMovementService }) => {
+    await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+    const isRollbackLastReceiptButtonVisible =
+      await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
+    const isRollbackButtonVisible =
+      await stockMovementShowPage.rollbackButton.isVisible();
+
+    // due to failed test, shipment might not be received which will not show the button
+    if (isRollbackLastReceiptButtonVisible) {
+      await stockMovementShowPage.rollbackLastReceiptButton.click();
+    }
+
+    if (isRollbackButtonVisible) {
+      await stockMovementShowPage.rollbackButton.click();
+    }
+
+    await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+  });
+
+  test('Apply sorting by alphabetical order and remain inputs', async ({
+    stockMovementShowPage,
+    receivingPage,
+    fifthProductService,
+    createInboundPage,
+  }) => {
+    await test.step('Go to stock movement show page', async () => {
+      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+      await stockMovementShowPage.isLoaded();
+    });
+
+    await test.step('Edit created shipment and add item', async () => {
+      await stockMovementShowPage.editButton.click();
+      await createInboundPage.sendStep.isLoaded();
+      await createInboundPage.sendStep.shipmentTypeSelect.findAndSelectOption(
+        SHIPMENT_TYPE
+      );
+      await createInboundPage.sendStep.expectedDeliveryDatePicker.fill(
+        EXPECTED_DELIVERY_DATE
+      );
+      await createInboundPage.sendStep.isLoaded();
+      await createInboundPage.previousButton.click();
+      await createInboundPage.addItemsStep.isLoaded();
+      await createInboundPage.addItemsStep.reloadButton.click();
+      await createInboundPage.addItemsStep.confirmReloadPopup.yesButton.click();
+      await createInboundPage.addItemsStep.isLoaded();
+      await createInboundPage.addItemsStep.addLineButton.click();
+      const item = await fifthProductService.getProduct();
+      const row = createInboundPage.addItemsStep.table.row(2);
+      await row.productSelect.findAndSelectOption(item.name);
+      await row.quantityField.numberbox.fill('100');
+    });
+
+    await test.step('Send shipment', async () => {
+      await createInboundPage.nextButton.click();
+      await createInboundPage.sendStep.isLoaded();
+      await createInboundPage.sendStep.sendShipmentButton.click();
+      await stockMovementShowPage.waitForUrl();
+      await stockMovementShowPage.isLoaded();
+    });
+
+    await test.step('Go to shipment receiving page', async () => {
+      await stockMovementShowPage.receiveButton.click();
+      await receivingPage.receivingStep.isLoaded();
+    });
+
+    await test.step('Input receiving qty for all lines', async () => {
+      await receivingPage.receivingStep.table
+        .row(1)
+        .receivingNowField.textbox.fill('50');
+      await receivingPage.receivingStep.table
+        .row(2)
+        .receivingNowField.textbox.fill('50');
+      await receivingPage.receivingStep.table
+        .row(3)
+        .receivingNowField.textbox.fill('50');
+    });
+
+    await test.step('Change ordering to alphabetical and assert order', async () => {
+      const item = await fifthProductService.getProduct();
+      await receivingPage.receivingStep.table.row(3).getItem(item.name).hover();
+      await expect(receivingPage.tooltip).toContainText(item.name);
+      await receivingPage.receivingStep.orderSelect.click();
+      await receivingPage.receivingStep.getOrder('Alphabetical Order').click();
+      await receivingPage.receivingStep.table.row(1).getItem(item.name).hover();
+      await expect(receivingPage.tooltip).toContainText(item.name);
+      await expect(
+        receivingPage.receivingStep.table.row(1).receivingNowField.textbox
+      ).toHaveValue('50');
+      await expect(
+        receivingPage.receivingStep.table.row(2).receivingNowField.textbox
+      ).toHaveValue('50');
+      await expect(
+        receivingPage.receivingStep.table.row(3).receivingNowField.textbox
+      ).toHaveValue('50');
+    });
+
+    await test.step('Go to check page and assert applied order', async () => {
+      const item = await fifthProductService.getProduct();
+      await receivingPage.nextButton.click();
+      await receivingPage.checkStep.isLoaded();
+      await receivingPage.checkStep.table.row(1).getItem(item.name).hover();
+      await expect(receivingPage.tooltip).toContainText(item.name);
+    });
+
+    await test.step('Go back to receive page and change order to shipment', async () => {
+      const item = await fifthProductService.getProduct();
+      await receivingPage.checkStep.backToEditButton.click();
+      await receivingPage.receivingStep.isLoaded();
+      await receivingPage.receivingStep.orderSelect.click();
+      await receivingPage.receivingStep.getOrder('Shipment Order').click();
+      await receivingPage.receivingStep.table.row(3).getItem(item.name).hover();
+      await expect(receivingPage.tooltip).toContainText(item.name);
+    });
+
+    await test.step('Receive shipment', async () => {
+      await receivingPage.nextButton.click();
+      await receivingPage.checkStep.isLoaded();
+      await receivingPage.checkStep.receiveShipmentButton.click();
+      await stockMovementShowPage.isLoaded();
+    });
+  });
+});

--- a/src/tests/receiving/sortByAlphabeticalOrderAndRemainInputs.test.ts
+++ b/src/tests/receiving/sortByAlphabeticalOrderAndRemainInputs.test.ts
@@ -114,6 +114,12 @@ test.describe('Apply sorting by alphabetical order and remain inputs', () => {
       const item = await fifthProductService.getProduct();
       await receivingPage.receivingStep.table.row(3).getItem(item.name).hover();
       await expect(receivingPage.tooltip).toContainText(item.name);
+      await expect(receivingPage.receivingStep.orderSelect).toBeVisible();
+      await expect(
+        receivingPage.receivingStep.orderSelect.locator(
+          '.react-select__clear-indicator'
+        )
+      ).toBeHidden();
       await receivingPage.receivingStep.orderSelect.click();
       await receivingPage.receivingStep.getOrder('Alphabetical Order').click();
       await receivingPage.receivingStep.table.row(1).getItem(item.name).hover();


### PR DESCRIPTION
- I needed to edit shipment created through API because it forces alphabetical order of items so I won't be able to verify changes of order items. 
- I edited product name just to increase visibility 
- I added reload on add items to inbound page because without it the action was too fast and I had "loading..." line visible so I needed to make sure that page is loaded correctly before adding a new line
- I added test to receive inbound for newly introduced behavior: when remove qty and save default to 0 - but I needed to add skip for this test as I realized that obdev5 doesn't have all changes from release branch at the moment and it has inbound refactor feature branch so once obdev5 will be up-to-date we can unskip the test 