### PR TITLE
OBPIH-7035 Export stock movements from inbound list 

### DIFF
--- a/src/pages/inbound/list/InboundListPage.ts
+++ b/src/pages/inbound/list/InboundListPage.ts
@@ -25,6 +25,14 @@ class InboundListPage extends BasePageModel {
     return this.page.getByRole('link', { name: 'Export all incoming items' });
   }
 
+  get exportStockMovementsButton() {
+    return this.page.getByRole('button', { name: 'Export Stock Movements' });
+  }
+
+  get myStockMovementsButton() {
+    return this.page.getByRole('button', { name: 'My Stock Movements' });
+  }
+
   async goToPage() {
     await this.page.goto('./stockMovement/list?direction=INBOUND');
   }
@@ -55,6 +63,13 @@ class InboundListPage extends BasePageModel {
     await this.fileHandler.onDownload();
     await this.exportDropdownButton.click();
     await this.exportAllIncomingItemsButton.click();
+    return await this.fileHandler.saveFile();
+  }
+
+  async exportStockMovements() {
+    await this.fileHandler.onDownload();
+    await this.exportDropdownButton.click();
+    await this.exportStockMovementsButton.click();
     return await this.fileHandler.saveFile();
   }
 }

--- a/src/pages/inbound/list/InboundStockMovementTable.ts
+++ b/src/pages/inbound/list/InboundStockMovementTable.ts
@@ -30,6 +30,10 @@ class InboundStockMovementTable extends BasePageModel {
   get emptyInboundList() {
     return this.table.locator('.rt-noData');
   }
+
+  get stocklistColumnHeader() {
+    return this.table.getByRole('button', { name: 'Stocklist' });
+  }
 }
 
 class Row extends BasePageModel {

--- a/src/pages/stockMovementShow/StockMovementShowPage.ts
+++ b/src/pages/stockMovementShow/StockMovementShowPage.ts
@@ -44,6 +44,10 @@ class StockMovementShowPage extends BasePageModel {
     return this.summary.getByTestId('status-tag');
   }
 
+  get title() {
+    return this.summary.getByTestId('title');
+  }
+
   // TABS
   get packingListTab() {
     return this.page.getByRole('tab', { name: 'Packing List' });

--- a/src/pages/stockMovementShow/components/DetailsTable.ts
+++ b/src/pages/stockMovementShow/components/DetailsTable.ts
@@ -22,6 +22,14 @@ class DetailsTable extends BasePageModel {
   get identifierValue() {
     return this.identifierRow.locator('.value');
   }
+
+  get destinationRow() {
+    return this.rows.filter({ hasText: 'Destination' });
+  }
+
+  get destinationValue() {
+    return this.destinationRow.locator('.value');
+  }
 }
 
 export default DetailsTable;

--- a/src/tests/inbound/createInbound/createInbound.test.ts
+++ b/src/tests/inbound/createInbound/createInbound.test.ts
@@ -163,6 +163,11 @@ test.describe('Create inbound stock movement', () => {
       ).toContainText(
         `${formatDate(new Date(), 'DD/MMM/YYYY')} by ${USER.name}`
       );
+      await expect(
+        stockMovementShowPage.auditingTable.dateCreatedRow
+      ).toContainText(
+        `${formatDate(new Date(), 'DD/MMM/YYYY')} by ${USER.name}`
+      );
     });
   });
 });

--- a/src/tests/inbound/createInbound/editDestinationFromSendPage.test.ts
+++ b/src/tests/inbound/createInbound/editDestinationFromSendPage.test.ts
@@ -1,0 +1,80 @@
+import AppConfig from '@/config/AppConfig';
+import { ShipmentType } from '@/constants/ShipmentType';
+import { expect, test } from '@/fixtures/fixtures';
+import { StockMovementResponse } from '@/types';
+
+test.describe('Edit destination from send page', () => {
+  let STOCK_MOVEMENT: StockMovementResponse;
+
+  test.beforeEach(
+    async ({
+      supplierLocationService,
+      stockMovementService,
+      otherProductService,
+      thirdProductService,
+    }) => {
+      const supplierLocation = await supplierLocationService.getLocation();
+      const PRODUCT_TWO = await otherProductService.getProduct();
+      const PRODUCT_THREE = await thirdProductService.getProduct();
+
+      STOCK_MOVEMENT = await stockMovementService.createInbound({
+        originId: supplierLocation.id,
+      });
+
+      await stockMovementService.addItemsToInboundStockMovement(
+        STOCK_MOVEMENT.id,
+        [
+          { productId: PRODUCT_TWO.id, quantity: 100 },
+          { productId: PRODUCT_THREE.id, quantity: 200 },
+        ]
+      );
+
+      await stockMovementService.sendInboundStockMovement(STOCK_MOVEMENT.id, {
+        shipmentType: ShipmentType.AIR,
+      });
+    }
+  );
+
+  test.afterEach(
+    async ({ stockMovementShowPage, stockMovementService, authService }) => {
+      await authService.changeLocation(AppConfig.instance.locations.depot.id);
+      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+      await stockMovementShowPage.rollbackButton.click();
+      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await authService.changeLocation(AppConfig.instance.locations.main.id);
+    }
+  );
+
+  test('Edit destination from Send Page', async ({
+    stockMovementShowPage,
+    createInboundPage,
+    depotLocationService,
+  }) => {
+    const updatedDestination = await depotLocationService.getLocation();
+
+    await test.step('Go to stock movement show page', async () => {
+      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+      await stockMovementShowPage.isLoaded();
+    });
+
+    await test.step('Go to Send page od shipped sm and edit destination', async () => {
+      await stockMovementShowPage.editButton.click();
+      await createInboundPage.sendStep.isLoaded();
+      await createInboundPage.sendStep.destinationSelect.findAndSelectOption(
+        updatedDestination.name
+      );
+      await createInboundPage.sendStep.saveAndExitButton.click();
+      await stockMovementShowPage.isLoaded();
+    });
+
+    await test.step('Assert edited destination on show page', async () => {
+      await stockMovementShowPage.isLoaded();
+      await expect(
+        stockMovementShowPage.detailsListTable.destinationValue
+      ).toHaveText(updatedDestination.name);
+      await expect(stockMovementShowPage.title).toContainText(
+        `${updatedDestination.locationNumber}`
+      );
+    });
+  });
+});

--- a/src/tests/inbound/listPage/exportStockMovements.test.ts
+++ b/src/tests/inbound/listPage/exportStockMovements.test.ts
@@ -1,0 +1,176 @@
+import { ShipmentType } from '@/constants/ShipmentType';
+import { expect, test } from '@/fixtures/fixtures';
+import { StockMovementResponse } from '@/types';
+import { formatDate, getToday } from '@/utils/DateUtils';
+import { WorkbookUtils } from '@/utils/WorkbookUtils';
+
+test.describe('Export stock movements', () => {
+  let INBOUND1: StockMovementResponse;
+  let INBOUND2: StockMovementResponse;
+  const workbooks: WorkbookUtils[] = [];
+  const TODAY = getToday();
+
+  test.beforeEach(
+    async ({
+      supplierLocationService,
+      stockMovementService,
+      mainProductService,
+      otherProductService,
+    }) => {
+      const supplierLocation = await supplierLocationService.getLocation();
+      const PRODUCT_ONE = await mainProductService.getProduct();
+      const PRODUCT_TWO = await otherProductService.getProduct();
+
+      INBOUND1 = await stockMovementService.createInbound({
+        originId: supplierLocation.id,
+      });
+
+      await stockMovementService.addItemsToInboundStockMovement(INBOUND1.id, [
+        {
+          productId: PRODUCT_ONE.id,
+          quantity: 50,
+        },
+        { productId: PRODUCT_TWO.id, quantity: 100 },
+      ]);
+
+      await stockMovementService.sendInboundStockMovement(INBOUND1.id, {
+        shipmentType: ShipmentType.AIR,
+      });
+
+      INBOUND2 = await stockMovementService.createInbound({
+        originId: supplierLocation.id,
+      });
+
+      await stockMovementService.addItemsToInboundStockMovement(INBOUND2.id, [
+        {
+          productId: PRODUCT_ONE.id,
+          quantity: 50,
+        },
+      ]);
+    }
+  );
+
+  test.afterEach(async ({ stockMovementService, stockMovementShowPage }) => {
+    await stockMovementShowPage.goToPage(INBOUND1.id);
+    await stockMovementShowPage.isLoaded();
+    await stockMovementShowPage.rollbackButton.click();
+    await stockMovementService.deleteStockMovement(INBOUND1.id);
+    await stockMovementShowPage.goToPage(INBOUND2.id);
+    await stockMovementShowPage.isLoaded();
+    await stockMovementService.deleteStockMovement(INBOUND2.id);
+
+    for (const workbook of workbooks) {
+      workbook.delete();
+    }
+  });
+
+  test('Export Stock Movements', async ({ inboundListPage }) => {
+    await test.step('Go to inbound list page', async () => {
+      await inboundListPage.goToPage();
+    });
+
+    let filePath: string;
+    let exportStockMovements: WorkbookUtils;
+
+    const ROWS = [
+      {
+        status: 'CHECKING',
+        receiptStatus: 'PENDING',
+        identifier: INBOUND2.identifier,
+        name: INBOUND2.description,
+        origin: INBOUND2.origin.name,
+        destination: INBOUND2.destination.name,
+        stocklist: undefined,
+        requestedBy: INBOUND2.requestedBy.name,
+        dateRequested: INBOUND2.dateRequested.replace(/\//g, '-'),
+        dateCreated: INBOUND2.dateCreated.replace(/\//g, '-'),
+        dateShipped: formatDate(TODAY, 'MM-DD-YYYY'),
+      },
+      {
+        status: 'ISSUED',
+        receiptStatus: 'SHIPPED',
+        identifier: INBOUND1.identifier,
+        name: INBOUND1.description,
+        origin: INBOUND1.origin.name,
+        destination: INBOUND1.destination.name,
+        stocklist: undefined,
+        requestedBy: INBOUND1.requestedBy.name,
+        dateRequested: INBOUND1.dateRequested.replace(/\//g, '-'),
+        dateCreated: INBOUND1.dateCreated.replace(/\//g, '-'),
+        dateShipped: formatDate(TODAY, 'MM-DD-YYYY'),
+      },
+    ];
+
+    await test.step('Download file', async () => {
+      const { fullFilePath } = await inboundListPage.exportStockMovements();
+      filePath = fullFilePath;
+    });
+
+    let parsedDocumentData: unknown[][];
+
+    await test.step('Read file', async () => {
+      exportStockMovements = WorkbookUtils.read(filePath);
+      workbooks.push(exportStockMovements);
+      parsedDocumentData = exportStockMovements.getData();
+    });
+
+    await test.step('Assert template columns', async () => {
+      expect(exportStockMovements.getHeaders()).toStrictEqual([
+        'Status',
+        'Receipt Status',
+        'Identifier',
+        'Name',
+        'Origin',
+        'Destination',
+        'Stocklist',
+        'Requested by',
+        'Date Requested',
+        'Date Created',
+        'Date Shipped',
+      ]);
+    });
+
+    for (let i = 0; i < ROWS.length; i++) {
+      await test.step(`Assert data of exported template on row: ${i}`, async () => {
+        const documentRow = parsedDocumentData[i];
+        const row = ROWS[i];
+
+        expect(documentRow[0]).toEqual(row.status);
+        expect(documentRow[1]).toEqual(row.receiptStatus);
+        expect(documentRow[2]).toEqual(row.identifier);
+        expect(documentRow[3]).toEqual(row.name);
+        expect(documentRow[4]).toEqual(row.origin);
+        expect(documentRow[5]).toEqual(row.destination);
+        expect(documentRow[6]).toEqual(row.stocklist);
+        expect(documentRow[7]).toEqual(row.requestedBy);
+        expect(documentRow[8]).toEqual(row.dateRequested);
+        expect(documentRow[9]).toEqual(row.dateCreated);
+        expect(documentRow[10]).toEqual(row.dateShipped);
+      });
+    }
+
+    await test.step('Use search bar and apply filtering', async () => {
+      await inboundListPage.filters.searchField.textbox.fill(
+        INBOUND2.identifier
+      );
+      await inboundListPage.search();
+    });
+
+    await test.step('Download filtered file', async () => {
+      const { fullFilePath } = await inboundListPage.exportStockMovements();
+      filePath = fullFilePath;
+    });
+
+    await test.step('Read file', async () => {
+      exportStockMovements = WorkbookUtils.read(filePath);
+      workbooks.push(exportStockMovements);
+      parsedDocumentData = exportStockMovements.getData();
+      expect(parsedDocumentData).toHaveLength(1);
+    });
+
+    await test.step('Assert filtered file', async () => {
+      const documentRow = parsedDocumentData[0];
+      expect(documentRow[2]).toEqual(ROWS[0].identifier);
+    });
+  });
+});

--- a/src/tests/inbound/listPage/myStockMovementFilter.test.ts
+++ b/src/tests/inbound/listPage/myStockMovementFilter.test.ts
@@ -1,0 +1,83 @@
+import { ShipmentType } from '@/constants/ShipmentType';
+import { expect, test } from '@/fixtures/fixtures';
+import { StockMovementResponse, User } from '@/types';
+
+test.describe('My Stock Movement filter', () => {
+  let INBOUND: StockMovementResponse;
+  let USER: User;
+
+  test.beforeEach(
+    async ({
+      supplierLocationService,
+      mainUserService,
+      stockMovementService,
+      mainProductService,
+      otherProductService,
+    }) => {
+      const supplierLocation = await supplierLocationService.getLocation();
+      USER = await mainUserService.getUser();
+      const PRODUCT_ONE = await mainProductService.getProduct();
+      const PRODUCT_TWO = await otherProductService.getProduct();
+
+      INBOUND = await stockMovementService.createInbound({
+        originId: supplierLocation.id,
+      });
+
+      await stockMovementService.addItemsToInboundStockMovement(INBOUND.id, [
+        {
+          productId: PRODUCT_ONE.id,
+          quantity: 50,
+        },
+        { productId: PRODUCT_TWO.id, quantity: 100 },
+      ]);
+
+      await stockMovementService.sendInboundStockMovement(INBOUND.id, {
+        shipmentType: ShipmentType.AIR,
+      });
+    }
+  );
+
+  test.afterEach(async ({ stockMovementService, stockMovementShowPage }) => {
+    await stockMovementShowPage.goToPage(INBOUND.id);
+    await stockMovementShowPage.isLoaded();
+    await stockMovementShowPage.rollbackButton.click();
+    await stockMovementService.deleteStockMovement(INBOUND.id);
+  });
+
+  test('Apply and assert My Stock Movement filter', async ({
+    inboundListPage,
+  }) => {
+    await test.step('Go to inbound list page', async () => {
+      await inboundListPage.goToPage();
+      await inboundListPage.myStockMovementsButton.click();
+      await expect(
+        inboundListPage.filters.requestedBySelect.field
+      ).toContainText(USER.name);
+      await expect(inboundListPage.filters.createdBySelect.field).toContainText(
+        USER.name
+      );
+    });
+
+    await test.step('Assert stock movement to be visible in the table', async () => {
+      await expect(inboundListPage.table.table).toContainText(
+        INBOUND.identifier
+      );
+    });
+  });
+
+  test('Sorting by stocklist column should not remove items from table', async ({
+    inboundListPage,
+  }) => {
+    await test.step('Go to inbound list page', async () => {
+      await inboundListPage.goToPage();
+    });
+
+    await test.step('Click stocklist header and assert list content', async () => {
+      await inboundListPage.table.stocklistColumnHeader.click();
+      await expect(inboundListPage.table.table).not.toBeEmpty();
+      await expect(inboundListPage.table.table).toContainText(
+        INBOUND.identifier
+      );
+    });
+  });
+});


### PR DESCRIPTION
added tests:
- for export stock movements from inbound list 
- apply my stock movement filtering
- click stocklist header on inbound list (it should not remove table content)
- add test for edit destination from send page in shipped inbound 
- add assertion for date created on stock movement view page 
