### PR TITLE
OBPIH-6391 adjust tests to changes to status filter

### DIFF
--- a/src/tests/inbound/listPage/filters.test.ts
+++ b/src/tests/inbound/listPage/filters.test.ts
@@ -71,7 +71,7 @@ test.describe('Switch locations on inbound list page', () => {
 
     const filters = {
       search: 'TEST',
-      receiptStatus: 'Created',
+      receiptStatus: 'Pending',
       destination: mainLocation.name,
       origin: supplierLocation.name,
       shipmentType: 'Air',
@@ -207,7 +207,7 @@ test('Clicking clear button should clear all of the editable filters', async ({
 
   const filters = {
     search: 'TEST',
-    receiptStatus: 'Created',
+    receiptStatus: 'Pending',
     destination: mainLocation.name,
     origin: supplierLocation.name,
     shipmentType: 'Air',


### PR DESCRIPTION
in OBPIH-6391 Created status was removed from status filter on inbound list page so tests were failing, it is just a small fix to adjust test to code changes 