### PR TITLE
OBPIH-7919: Improve deleting shipments in receiving tests 

### DIFF
--- a/src/tests/putaway/sortPutawayByCurrentPreferredAndOriginalOrder.test.ts
+++ b/src/tests/putaway/sortPutawayByCurrentPreferredAndOriginalOrder.test.ts
@@ -164,11 +164,9 @@ test.describe('Sort putaway by current bin, preferred bin and original order', (
       await createPutawayPage.startStep.isLoaded();
 
       // Putaway A into binTwo (its preferred bin is auto-suggested).
-      await createPutawayPage.startStep.table.row(0).putawayBinSelect.click();
-      await createPutawayPage.startStep.table
-        .row(0)
-        .getPutawayBin(binTwo.name)
-        .click();
+      await expect(
+        createPutawayPage.startStep.table.row(0).putawayBinSelect
+      ).toContainText(binTwo.name);
       await createPutawayPage.startStep.nextButton.click();
       await createPutawayPage.completeStep.isLoaded();
       await createPutawayPage.completeStep.completePutawayButton.click();

--- a/src/tests/receiving/assertBinLocationField.test.ts
+++ b/src/tests/receiving/assertBinLocationField.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Assert bin location not clearable', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -45,22 +46,16 @@ test.describe('Assert bin location not clearable', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isRollbackLastReceiptButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-      const isRollbackButtonVisible =
-        await stockMovementShowPage.rollbackButton.isVisible();
 
-      if (isRollbackLastReceiptButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      if (isRollbackButtonVisible) {
-        await stockMovementShowPage.rollbackButton.click();
-      }
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await BinLocationUtils.deactivateReceivingBin({

--- a/src/tests/receiving/assertCreationOfGoodsReceiptNote.test.ts
+++ b/src/tests/receiving/assertCreationOfGoodsReceiptNote.test.ts
@@ -5,6 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { pageContainsValues } from '@/utils/pageUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 import { captureRowValues } from '@/utils/tableUtils';
 
 test.describe('Assert Goods Receipt Note is created and opened', () => {
@@ -46,11 +47,16 @@ test.describe('Assert Goods Receipt Note is created and opened', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await stockMovementShowPage.rollbackLastReceiptButton.click();
-      await stockMovementShowPage.rollbackButton.click();
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await BinLocationUtils.deactivateReceivingBin({

--- a/src/tests/receiving/assertCreationOfReceivingBin.test.ts
+++ b/src/tests/receiving/assertCreationOfReceivingBin.test.ts
@@ -7,6 +7,7 @@ import CreateLocationPage from '@/pages/location/createLocation/CreateLocationPa
 import LocationListPage from '@/pages/location/LocationListPage';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Assert creation of receiving bin', () => {
   test.describe.configure({ timeout: 60000 });
@@ -52,10 +53,16 @@ test.describe('Assert creation of receiving bin', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await stockMovementShowPage.rollbackButton.click();
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/assertQtyInputs.test.ts
+++ b/src/tests/receiving/assertQtyInputs.test.ts
@@ -5,6 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { formatDate, getDateByOffset } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Assert if quantity inputs remain when split lines', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -50,22 +51,16 @@ test.describe('Assert if quantity inputs remain when split lines', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isRollbackLastReceiptButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-      const isRollbackButtonVisible =
-        await stockMovementShowPage.rollbackButton.isVisible();
 
-      if (isRollbackLastReceiptButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      if (isRollbackButtonVisible) {
-        await stockMovementShowPage.rollbackButton.click();
-      }
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/assertRecipientField.test.ts
+++ b/src/tests/receiving/assertRecipientField.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Assert recipient field when receive', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -53,22 +54,16 @@ test.describe('Assert recipient field when receive', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isRollbackLastReceiptButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-      const isRollbackButtonVisible =
-        await stockMovementShowPage.rollbackButton.isVisible();
 
-      if (isRollbackLastReceiptButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      if (isRollbackButtonVisible) {
-        await stockMovementShowPage.rollbackButton.click();
-      }
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/cancelRemainingQty.test.ts
+++ b/src/tests/receiving/cancelRemainingQty.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Cancel qty in the middle of receipt', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -47,22 +48,16 @@ test.describe('Cancel qty in the middle of receipt', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isRollbackLastReceiptButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-      const isRollbackButtonVisible =
-        await stockMovementShowPage.rollbackButton.isVisible();
 
-      if (isRollbackLastReceiptButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      if (isRollbackButtonVisible) {
-        await stockMovementShowPage.rollbackButton.click();
-      }
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await BinLocationUtils.deactivateReceivingBin({

--- a/src/tests/receiving/editBinLocationWhenReceive.test.ts
+++ b/src/tests/receiving/editBinLocationWhenReceive.test.ts
@@ -5,6 +5,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 test.describe('Edit Bin Location when receive inbound stock movement', () => {
@@ -74,23 +75,19 @@ test.describe('Edit Bin Location when receive inbound stock movement', () => {
       locationListPage,
       mainLocationService,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       const mainLocation = await mainLocationService.getLocation();
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
 
-      const hasRollbackLastReceipt =
-        await stockMovementShowPage.rollbackLastReceiptButton
-          .isVisible()
-          .catch(() => false);
-
-      if (hasRollbackLastReceipt) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      await stockMovementShowPage.rollbackButton.click();
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       await test.step('Deactivate created bin location', async () => {
         await page.goto(LOCATION_URL.list());
@@ -275,14 +272,19 @@ test.describe('Edit Bin Location to bin with zone when receive inbound stock mov
       locationListPage,
       mainLocationService,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       const mainLocation = await mainLocationService.getLocation();
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await stockMovementShowPage.rollbackLastReceiptButton.click();
-      await stockMovementShowPage.rollbackButton.click();
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       await test.step('Deactivate created bin location', async () => {
         await page.goto(LOCATION_URL.list());
@@ -468,14 +470,19 @@ test.describe('Edit Bin Location when receive for all lines', () => {
       locationListPage,
       mainLocationService,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       const mainLocation = await mainLocationService.getLocation();
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await stockMovementShowPage.rollbackLastReceiptButton.click();
-      await stockMovementShowPage.rollbackButton.click();
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       await test.step('Deactivate created bin location', async () => {
         await page.goto(LOCATION_URL.list());

--- a/src/tests/receiving/editOriginalLineQtyTo0.test.ts
+++ b/src/tests/receiving/editOriginalLineQtyTo0.test.ts
@@ -5,6 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getDateByOffset } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 test.describe('Edit qty of original line to 0', () => {
@@ -63,22 +64,16 @@ test.describe('Edit qty of original line to 0', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isRollbackLastReceiptButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-      const isRollbackButtonVisible =
-        await stockMovementShowPage.rollbackButton.isVisible();
 
-      if (isRollbackLastReceiptButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      if (isRollbackButtonVisible) {
-        await stockMovementShowPage.rollbackButton.click();
-      }
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
@@ -264,22 +259,16 @@ test.describe('Edit original line to other product in the middle of receipt', ()
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isRollbackLastReceiptButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-      const isRollbackButtonVisible =
-        await stockMovementShowPage.rollbackButton.isVisible();
 
-      if (isRollbackLastReceiptButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      if (isRollbackButtonVisible) {
-        await stockMovementShowPage.rollbackButton.click();
-      }
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await BinLocationUtils.deactivateReceivingBin({

--- a/src/tests/receiving/editsInReceiving.test.ts
+++ b/src/tests/receiving/editsInReceiving.test.ts
@@ -5,6 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { formatDate, getDateByOffset, getToday } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 test.describe('Edit items in the middle of receipt', () => {
@@ -56,22 +57,16 @@ test.describe('Edit items in the middle of receipt', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isRollbackLastReceiptButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-      const isRollbackButtonVisible =
-        await stockMovementShowPage.rollbackButton.isVisible();
 
-      if (isRollbackLastReceiptButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      if (isRollbackButtonVisible) {
-        await stockMovementShowPage.rollbackButton.click();
-      }
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/exportReceivingTemplate.test.ts
+++ b/src/tests/receiving/exportReceivingTemplate.test.ts
@@ -7,6 +7,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { formatDate, getDateByOffset } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 import { WorkbookUtils } from '@/utils/WorkbookUtils';
 
@@ -59,11 +60,16 @@ test.describe('Export receiving template', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await stockMovementShowPage.rollbackLastReceiptButton.click();
-      await stockMovementShowPage.rollbackButton.click();
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       for (const workbook of workbooks) {
         workbook.delete();

--- a/src/tests/receiving/importReceivingTemplate.test.ts
+++ b/src/tests/receiving/importReceivingTemplate.test.ts
@@ -7,6 +7,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getDateByOffset } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 import { WorkbookUtils } from '@/utils/WorkbookUtils';
 
@@ -58,18 +59,16 @@ test.describe('Import receiving template', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
 
-      if (isButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      await stockMovementShowPage.rollbackButton.click();
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       for (const workbook of workbooks) {
         workbook.delete();

--- a/src/tests/receiving/lotExpirySystemUpdateOnReceiving.test.ts
+++ b/src/tests/receiving/lotExpirySystemUpdateOnReceiving.test.ts
@@ -5,6 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { formatDate, getDateByOffset, getToday } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 test.describe('Lot number system expiry date modification on receiving workflow', () => {
@@ -18,6 +19,7 @@ test.describe('Lot number system expiry date modification on receiving workflow'
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       // TODO: Improve this one, it is prone to getting stuck if there are not deleted SMs in the tested location
       while (STOCK_MOVEMENTS.length > 0) {
@@ -29,18 +31,13 @@ test.describe('Lot number system expiry date modification on receiving workflow'
           await stockMovementShowPage.isLoaded();
         });
 
-        const isButtonVisible =
-          await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-        if (isButtonVisible) {
-          await stockMovementShowPage.rollbackLastReceiptButton.click();
-        }
-
-        await test.step('Rollback shipment', async () => {
-          await stockMovementShowPage.rollbackButton.click();
-        });
-
         await test.step(`Delete stock movement "${STOCK_MOVEMENT.id}"`, async () => {
-          await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+          await deleteReceivedShipment({
+            stockMovementShowPage,
+            oldViewShipmentPage,
+            stockMovementService,
+            STOCK_MOVEMENT,
+          });
         });
 
         const receivingBin =

--- a/src/tests/receiving/receiveInbound.test.ts
+++ b/src/tests/receiving/receiveInbound.test.ts
@@ -5,6 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { formatDate, getToday } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Receive inbound stock movement', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -50,18 +51,16 @@ test.describe('Receive inbound stock movement', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
 
-      if (isButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      await stockMovementShowPage.rollbackButton.click();
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
@@ -416,11 +415,20 @@ test.describe('Receive from different locations', () => {
   );
 
   test.afterEach(
-    async ({ authService, stockMovementShowPage, stockMovementService }) => {
+    async ({
+      authService,
+      stockMovementShowPage,
+      stockMovementService,
+      oldViewShipmentPage,
+    }) => {
       await authService.changeLocation(AppConfig.instance.locations.main.id);
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await stockMovementShowPage.rollbackButton.click();
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
     }
   );
 

--- a/src/tests/receiving/receiveInboundWithoutPartialReceiving.test.ts
+++ b/src/tests/receiving/receiveInboundWithoutPartialReceiving.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import { formatDate, getToday } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Receive inbound stock movement in location without partial receiving', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -43,24 +44,23 @@ test.describe('Receive inbound stock movement in location without partial receiv
     }
   );
 
-  test.afterEach(async ({ stockMovementShowPage, authService }) => {
-    await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-    const isRollbackLastReceiptButtonVisible =
-      await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-    const isRollbackButtonVisible =
-      await stockMovementShowPage.rollbackButton.isVisible();
-
-    if (isRollbackLastReceiptButtonVisible) {
-      await stockMovementShowPage.rollbackLastReceiptButton.click();
+  test.afterEach(
+    async ({
+      stockMovementShowPage,
+      authService,
+      oldViewShipmentPage,
+      stockMovementService,
+    }) => {
+      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
+      await authService.changeLocation(AppConfig.instance.locations.main.id);
     }
-
-    if (isRollbackButtonVisible) {
-      await stockMovementShowPage.rollbackButton.click();
-    }
-
-    await stockMovementShowPage.clickDeleteShipment();
-    await authService.changeLocation(AppConfig.instance.locations.main.id);
-  });
+  );
 
   test('Assert Confirm receiving dialog and select No, receive 1 item fully', async ({
     stockMovementShowPage,

--- a/src/tests/receiving/receiveInboundWithoutPickAndPutawayStock.test.ts
+++ b/src/tests/receiving/receiveInboundWithoutPickAndPutawayStock.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import { getToday } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Receive inbound stock movement in location without pick and putaway stock', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -40,14 +41,24 @@ test.describe('Receive inbound stock movement in location without pick and putaw
     }
   );
 
-  test.afterEach(async ({ stockMovementShowPage, authService }) => {
-    await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-    await stockMovementShowPage.rollbackLastReceiptButton.click();
-    await stockMovementShowPage.rollbackButton.click();
-    await stockMovementShowPage.clickDeleteShipment();
+  test.afterEach(
+    async ({
+      stockMovementShowPage,
+      authService,
+      oldViewShipmentPage,
+      stockMovementService,
+    }) => {
+      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
-    await authService.changeLocation(AppConfig.instance.locations.main.id);
-  });
+      await authService.changeLocation(AppConfig.instance.locations.main.id);
+    }
+  );
 
   test('Receive sm in location without pick and putaway stock', async ({
     stockMovementShowPage,

--- a/src/tests/receiving/receiveToHoldBin.test.ts
+++ b/src/tests/receiving/receiveToHoldBin.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 test.describe('Receive item into hold bin', () => {
@@ -59,13 +60,17 @@ test.describe('Receive item into hold bin', () => {
       locationListPage,
       mainLocationService,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await stockMovementShowPage.rollbackLastReceiptButton.click();
-      await stockMovementShowPage.rollbackButton.click();
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       await test.step('Deactivate created bin location', async () => {
         await BinLocationUtils.deactivateCreatedBin({

--- a/src/tests/receiving/receivingStatusChanges.test.ts
+++ b/src/tests/receiving/receivingStatusChanges.test.ts
@@ -7,6 +7,7 @@ import StockMovementShowPage from '@/pages/stockMovementShow/StockMovementShowPa
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getToday } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Status changes on sm view page when receive shipment', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -51,22 +52,15 @@ test.describe('Status changes on sm view page when receive shipment', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isRollbackLastReceiptButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-      const isRollbackButtonVisible =
-        await stockMovementShowPage.rollbackButton.isVisible();
-
-      if (isRollbackLastReceiptButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      if (isRollbackButtonVisible) {
-        await stockMovementShowPage.rollbackButton.click();
-      }
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await BinLocationUtils.deactivateReceivingBin({

--- a/src/tests/receiving/receivingStatusChangesWithoutPartialReceiving.test.ts
+++ b/src/tests/receiving/receivingStatusChangesWithoutPartialReceiving.test.ts
@@ -6,6 +6,7 @@ import InboundListPage from '@/pages/inbound/list/InboundListPage';
 import StockMovementShowPage from '@/pages/stockMovementShow/StockMovementShowPage';
 import { StockMovementResponse } from '@/types';
 import { getToday } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Status changes on sm view page when receive shipment in location without partial receiving', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -45,24 +46,24 @@ test.describe('Status changes on sm view page when receive shipment in location 
     }
   );
 
-  test.afterEach(async ({ stockMovementShowPage, authService }) => {
-    await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-    const isRollbackLastReceiptButtonVisible =
-      await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-    const isRollbackButtonVisible =
-      await stockMovementShowPage.rollbackButton.isVisible();
+  test.afterEach(
+    async ({
+      stockMovementShowPage,
+      authService,
+      oldViewShipmentPage,
+      stockMovementService,
+    }) => {
+      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
-    if (isRollbackLastReceiptButtonVisible) {
-      await stockMovementShowPage.rollbackLastReceiptButton.click();
+      await authService.changeLocation(AppConfig.instance.locations.main.id);
     }
-
-    if (isRollbackButtonVisible) {
-      await stockMovementShowPage.rollbackButton.click();
-    }
-
-    await stockMovementShowPage.clickDeleteShipment();
-    await authService.changeLocation(AppConfig.instance.locations.main.id);
-  });
+  );
 
   test('Assert status changes on view page and receipt tab when receive 1 item partially', async ({
     stockMovementShowPage,

--- a/src/tests/receiving/rollbackStatusChanges.test.ts
+++ b/src/tests/receiving/rollbackStatusChanges.test.ts
@@ -7,6 +7,7 @@ import StockMovementShowPage from '@/pages/stockMovementShow/StockMovementShowPa
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getToday } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Status changes on sm view page when rollback receipts', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -51,10 +52,15 @@ test.describe('Status changes on sm view page when rollback receipts', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await stockMovementShowPage.rollbackButton.click();
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/sortByAlphabeticalOrderAndRemainInputs.test.ts
+++ b/src/tests/receiving/sortByAlphabeticalOrderAndRemainInputs.test.ts
@@ -4,6 +4,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getDateByOffset, getToday } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Apply sorting by alphabetical order and remain inputs', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -43,22 +44,15 @@ test.describe('Apply sorting by alphabetical order and remain inputs', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isRollbackLastReceiptButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-      const isRollbackButtonVisible =
-        await stockMovementShowPage.rollbackButton.isVisible();
-
-      if (isRollbackLastReceiptButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      if (isRollbackButtonVisible) {
-        await stockMovementShowPage.rollbackButton.click();
-      }
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/tableShortcutsInReceiving.test.ts
+++ b/src/tests/receiving/tableShortcutsInReceiving.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Use table shortcuts on receiving page', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -64,22 +65,15 @@ test.describe('Use table shortcuts on receiving page', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isRollbackLastReceiptButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-      const isRollbackButtonVisible =
-        await stockMovementShowPage.rollbackButton.isVisible();
-
-      if (isRollbackLastReceiptButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      if (isRollbackButtonVisible) {
-        await stockMovementShowPage.rollbackButton.click();
-      }
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/validationsOnDeliverOnDate.test.ts
+++ b/src/tests/receiving/validationsOnDeliverOnDate.test.ts
@@ -5,6 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getDateByOffset } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Validations on edit Deliver On Date when receiving shipment', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -41,11 +42,15 @@ test.describe('Validations on edit Deliver On Date when receiving shipment', () 
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await stockMovementShowPage.rollbackButton.click();
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
-
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await BinLocationUtils.deactivateReceivingBin({

--- a/src/tests/receiving/validationsOnEditAndReceive.test.ts
+++ b/src/tests/receiving/validationsOnEditAndReceive.test.ts
@@ -5,6 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getToday } from '@/utils/DateUtils';
+import { deleteReceivedShipment } from '@/utils/shipmentUtils';
 
 test.describe('Assert validation on try to receive not yet shipped inbound', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -104,22 +105,15 @@ test.describe('Validations on edit and receive inbound stock movement', () => {
       page,
       locationListPage,
       createLocationPage,
+      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      const isRollbackLastReceiptButtonVisible =
-        await stockMovementShowPage.rollbackLastReceiptButton.isVisible();
-      const isRollbackButtonVisible =
-        await stockMovementShowPage.rollbackButton.isVisible();
-
-      if (isRollbackLastReceiptButtonVisible) {
-        await stockMovementShowPage.rollbackLastReceiptButton.click();
-      }
-
-      if (isRollbackButtonVisible) {
-        await stockMovementShowPage.rollbackButton.click();
-      }
-
-      await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+      await deleteReceivedShipment({
+        stockMovementShowPage,
+        oldViewShipmentPage,
+        stockMovementService,
+        STOCK_MOVEMENT,
+      });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
@@ -228,6 +222,7 @@ test.describe('Validations on edit and receive inbound stock movement', () => {
   test('Assert unable to receive already received inbounds', async ({
     stockMovementShowPage,
     receivingPage,
+    page,
   }) => {
     await test.step('Go to stock movement show page', async () => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
@@ -258,8 +253,12 @@ test.describe('Validations on edit and receive inbound stock movement', () => {
 
     await test.step('Validation on receive already received inbound', async () => {
       await stockMovementShowPage.isLoaded();
+      // eslint-disable-next-line playwright/no-networkidle
+      await page.waitForLoadState('networkidle');
       await stockMovementShowPage.receiveButton.click();
-      await expect(stockMovementShowPage.errorMessage).toBeVisible();
+      await expect(stockMovementShowPage.errorMessage).toBeVisible({
+        timeout: 10000,
+      });
       await expect(stockMovementShowPage.errorMessage).toContainText(
         'Stock movement ' +
           STOCK_MOVEMENT.identifier +


### PR DESCRIPTION
Improving deleting received shipments in receiving e2e test to avoid random failures if some of the shipments won’t rollback/delete for any reason 