### PR TITLE
OBPIH-7931 Refactor deleting stock movements in receiving and putaway tests

### DIFF
--- a/src/api/StockMovementService.ts
+++ b/src/api/StockMovementService.ts
@@ -91,23 +91,23 @@ class StockMovementService extends BaseServiceModel {
 
   /*
     Rolls back shipment events (received, shipped) one by one until the
-    shipment is back in the pending state, so the stock movement can be
-    deleted regardless of the status it reached in the test.
+    shipment reaches the given status, e.g. back to PENDING so the stock
+    movement can be deleted regardless of the status it reached in the test.
   */
-  async rollbackShipmentToPending(id: string) {
+  async rollbackShipmentToStatus(id: string, status: string) {
     // a shipment accumulates one shipped event plus one receipt event per
     // (partial) receipt, so a sane shipment needs just a few rollbacks
     const maxRollbacks = 10;
     for (let i = 0; i < maxRollbacks; i++) {
       const { data } = await this.getStockMovement(id);
       const shipmentStatus = data?.associations?.shipment?.status;
-      if (!shipmentStatus || shipmentStatus === 'PENDING') {
+      if (!shipmentStatus || shipmentStatus === status) {
         return;
       }
       await this.rollbackLastShipmentStatus(id);
     }
     throw new Error(
-      `Shipment of stock movement ${id} did not get back to pending after ${maxRollbacks} rollbacks`
+      `Shipment of stock movement ${id} did not get back to ${status} after ${maxRollbacks} rollbacks`
     );
   }
 

--- a/src/api/StockMovementService.ts
+++ b/src/api/StockMovementService.ts
@@ -78,6 +78,39 @@ class StockMovementService extends BaseServiceModel {
     }
   }
 
+  async rollbackLastShipmentStatus(id: string) {
+    // request.delete does not throw on HTTP error statuses, and a swallowed
+    // failed rollback makes the follow-up delete fail with a status error
+    const apiResponse = await this.request.delete(STOCK_MOVEMENT_STATUS(id));
+    if (!apiResponse.ok()) {
+      throw new Error(
+        `Problem rolling back shipment status of stock movement ${id}: ${apiResponse.status()}`
+      );
+    }
+  }
+
+  /*
+    Rolls back shipment events (received, shipped) one by one until the
+    shipment is back in the pending state, so the stock movement can be
+    deleted regardless of the status it reached in the test.
+  */
+  async rollbackShipmentToPending(id: string) {
+    // a shipment accumulates one shipped event plus one receipt event per
+    // (partial) receipt, so a sane shipment needs just a few rollbacks
+    const maxRollbacks = 10;
+    for (let i = 0; i < maxRollbacks; i++) {
+      const { data } = await this.getStockMovement(id);
+      const shipmentStatus = data?.associations?.shipment?.status;
+      if (!shipmentStatus || shipmentStatus === 'PENDING') {
+        return;
+      }
+      await this.rollbackLastShipmentStatus(id);
+    }
+    throw new Error(
+      `Shipment of stock movement ${id} did not get back to pending after ${maxRollbacks} rollbacks`
+    );
+  }
+
   async getStockMovement(
     id: string
   ): Promise<ApiResponse<StockMovementResponse>> {

--- a/src/tests/putaway/addCommentToPutaway.test.ts
+++ b/src/tests/putaway/addCommentToPutaway.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -57,13 +57,7 @@ test.describe('Add comment to Putaway', () => {
   );
 
   test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      navbar,
-      transactionListPage,
-      oldViewShipmentPage,
-    }) => {
+    async ({ stockMovementService, navbar, transactionListPage }) => {
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       await transactionListPage.table.row(1).actionsButton.click();
@@ -73,12 +67,7 @@ test.describe('Add comment to Putaway', () => {
       await transactionListPage.table.deleteButton.click();
       await expect(transactionListPage.successMessage).toBeVisible();
 
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
     }
   );
 

--- a/src/tests/putaway/assertAttemptToEditCompletedPutaway.test.ts
+++ b/src/tests/putaway/assertAttemptToEditCompletedPutaway.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -57,13 +57,7 @@ test.describe('Assert attempt to edit completed putaway', () => {
   );
 
   test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      navbar,
-      transactionListPage,
-      oldViewShipmentPage,
-    }) => {
+    async ({ stockMovementService, navbar, transactionListPage }) => {
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       await transactionListPage.table.row(1).actionsButton.click();
@@ -73,12 +67,7 @@ test.describe('Assert attempt to edit completed putaway', () => {
       await transactionListPage.table.deleteButton.click();
       await expect(transactionListPage.successMessage).toBeVisible();
 
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
     }
   );
 

--- a/src/tests/putaway/assertPutawayDetailsPage.test.ts
+++ b/src/tests/putaway/assertPutawayDetailsPage.test.ts
@@ -10,7 +10,7 @@ import { deleteFile, writeBufferToFile } from '@/utils/FileIOUtils';
 import { pdfContainsValues } from '@/utils/pdfUtils';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -65,13 +65,7 @@ test.describe('Assert putaway details page', () => {
   );
 
   test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      navbar,
-      transactionListPage,
-      oldViewShipmentPage,
-    }) => {
+    async ({ stockMovementService, navbar, transactionListPage }) => {
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       await transactionListPage.table.row(1).actionsButton.click();
@@ -81,12 +75,7 @@ test.describe('Assert putaway details page', () => {
       await transactionListPage.table.deleteButton.click();
       await expect(transactionListPage.successMessage).toBeVisible();
 
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       while (downloadedFilePaths.length) {
         deleteFile(downloadedFilePaths.pop() as string);

--- a/src/tests/putaway/assertReceivingBinsOnCreatePutawayPage.test.ts
+++ b/src/tests/putaway/assertReceivingBinsOnCreatePutawayPage.test.ts
@@ -6,7 +6,7 @@ import { StockMovementResponse } from '@/types';
 import { formatDate, getDateByOffset } from '@/utils/DateUtils';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -123,29 +123,19 @@ test.describe('Assert receiving bin on create putaway page', () => {
   );
 
   test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      navbar,
-      transactionListPage,
-      oldViewShipmentPage,
-    }) => {
+    async ({ stockMovementService, navbar, transactionListPage }) => {
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       for (let n = 1; n < 4; n++) {
         await transactionListPage.deleteTransaction(1);
       }
 
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
+      await deleteShipment({
         stockMovementService,
         STOCK_MOVEMENT: PRIMARY_STOCK_MOVEMENT,
       });
 
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
+      await deleteShipment({
         stockMovementService,
         STOCK_MOVEMENT: SECONDARY_STOCK_MOVEMENT,
       });

--- a/src/tests/putaway/assertZonesInPutaways.test.ts
+++ b/src/tests/putaway/assertZonesInPutaways.test.ts
@@ -6,7 +6,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { ProductResponse, StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -141,11 +141,9 @@ test.describe('Assert zones on putaway pages', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       navbar,
       transactionListPage,
-      oldViewShipmentPage,
       productService,
       productShowPage,
       productEditPage,
@@ -160,12 +158,7 @@ test.describe('Assert zones on putaway pages', () => {
       for (let n = 1; n < 4; n++) {
         await transactionListPage.deleteTransaction(1);
       }
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
       const product = await productService.getProduct(Product.FOUR);
 
       await test.step('Delete inventory level', async () => {

--- a/src/tests/putaway/changeLocationOnCreatePutawayPage.test.ts
+++ b/src/tests/putaway/changeLocationOnCreatePutawayPage.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -58,32 +58,20 @@ test.describe('Change location on putaway create page and list pages', () => {
     }
   );
 
-  test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      putawayListPage,
-      oldViewShipmentPage,
-    }) => {
-      // the received shipment must be cleaned up even when the test fails
-      // before the putaway is created
-      if (putawayOrderIdentifier) {
-        await putawayListPage.goToPage();
-        await putawayListPage.table
-          .rowByOrderNumber(`${putawayOrderIdentifier}`.toString().trim())
-          .actionsButton.click();
-        await putawayListPage.table.clickDeleteOrderButton(1);
-        await putawayListPage.emptyPutawayList.isVisible();
-      }
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+  test.afterEach(async ({ stockMovementService, putawayListPage }) => {
+    // the received shipment must be cleaned up even when the test fails
+    // before the putaway is created
+    if (putawayOrderIdentifier) {
+      await putawayListPage.goToPage();
+      await putawayListPage.table
+        .rowByOrderNumber(`${putawayOrderIdentifier}`.toString().trim())
+        .actionsButton.click();
+      await putawayListPage.table.clickDeleteOrderButton(1);
+      await putawayListPage.emptyPutawayList.isVisible();
     }
-  );
+
+    await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
+  });
 
   test('Change location on putaway create page and list page', async ({
     stockMovementShowPage,

--- a/src/tests/putaway/createMoreThan1PutawayForTheSameItem.test.ts
+++ b/src/tests/putaway/createMoreThan1PutawayForTheSameItem.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -57,13 +57,7 @@ test.describe('Create more than 1 putaway from the same item', () => {
   );
 
   test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      navbar,
-      transactionListPage,
-      oldViewShipmentPage,
-    }) => {
+    async ({ stockMovementService, navbar, transactionListPage }) => {
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       await transactionListPage.table.row(1).actionsButton.click();
@@ -73,12 +67,7 @@ test.describe('Create more than 1 putaway from the same item', () => {
       await transactionListPage.table.deleteButton.click();
       await expect(transactionListPage.successMessage).toBeVisible();
 
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
     }
   );
 

--- a/src/tests/putaway/createPutaway.test.ts
+++ b/src/tests/putaway/createPutaway.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -57,13 +57,7 @@ test.describe('Putaway received inbound shipment', () => {
   );
 
   test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      navbar,
-      transactionListPage,
-      oldViewShipmentPage,
-    }) => {
+    async ({ stockMovementService, navbar, transactionListPage }) => {
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       await transactionListPage.table.row(1).actionsButton.click();
@@ -73,12 +67,7 @@ test.describe('Putaway received inbound shipment', () => {
       await transactionListPage.table.deleteButton.click();
       await expect(transactionListPage.successMessage).toBeVisible();
 
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
     }
   );
 

--- a/src/tests/putaway/deleteItemsFromPutaway.test.ts
+++ b/src/tests/putaway/deleteItemsFromPutaway.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { ProductResponse, StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -71,24 +71,13 @@ test.describe('Delete items from putaway', () => {
   );
 
   test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      navbar,
-      transactionListPage,
-      oldViewShipmentPage,
-    }) => {
+    async ({ stockMovementService, navbar, transactionListPage }) => {
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       for (let n = 1; n < 3; n++) {
         await transactionListPage.deleteTransaction(1);
       }
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
     }
   );
 

--- a/src/tests/putaway/deletePendingPutaway.test.ts
+++ b/src/tests/putaway/deletePendingPutaway.test.ts
@@ -10,7 +10,7 @@ import StockMovementShowPage from '@/pages/stockMovementShow/StockMovementShowPa
 import { StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -61,20 +61,9 @@ test.describe('Delete pending putaways', () => {
     }
   );
 
-  test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      oldViewShipmentPage,
-    }) => {
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
-    }
-  );
+  test.afterEach(async ({ stockMovementService }) => {
+    await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
+  });
 
   test('Delete pending putaway as superuser from list page', async ({
     stockMovementShowPage,

--- a/src/tests/putaway/performPutawayAsManagerUser.test.ts
+++ b/src/tests/putaway/performPutawayAsManagerUser.test.ts
@@ -9,7 +9,7 @@ import StockMovementShowPage from '@/pages/stockMovementShow/StockMovementShowPa
 import { ProductResponse, StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -80,19 +80,13 @@ test.describe('Perform putaway as manager user', () => {
       stockMovementService,
       navbar,
       transactionListPage,
-      oldViewShipmentPage,
     }) => {
       await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       await transactionListPage.deleteTransaction(1);
       await transactionListPage.deleteTransaction(1);
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
     }
   );
 

--- a/src/tests/putaway/putawayImtemWithEmptyLot.test.ts
+++ b/src/tests/putaway/putawayImtemWithEmptyLot.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -57,24 +57,13 @@ test.describe('Putaway item with empty lot', () => {
   );
 
   test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      navbar,
-      transactionListPage,
-      oldViewShipmentPage,
-    }) => {
+    async ({ stockMovementService, navbar, transactionListPage }) => {
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       for (let n = 1; n < 5; n++) {
         await transactionListPage.deleteTransaction(1);
       }
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
       await RefreshCachesUtils.refreshCaches({
         navbar,
       });

--- a/src/tests/putaway/putawayMoreThan1Item.test.ts
+++ b/src/tests/putaway/putawayMoreThan1Item.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { ProductResponse, StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -71,24 +71,13 @@ test.describe('Create putaway for more than 1 item, separate putaways', () => {
   );
 
   test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      navbar,
-      transactionListPage,
-      oldViewShipmentPage,
-    }) => {
+    async ({ stockMovementService, navbar, transactionListPage }) => {
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       for (let n = 1; n < 4; n++) {
         await transactionListPage.deleteTransaction(1);
       }
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
     }
   );
 

--- a/src/tests/putaway/putawayToHoldBin.test.ts
+++ b/src/tests/putaway/putawayToHoldBin.test.ts
@@ -6,7 +6,7 @@ import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -80,13 +80,11 @@ test.describe('Putaway item into hold bin', () => {
     async ({
       navbar,
       transactionListPage,
-      stockMovementShowPage,
       stockMovementService,
       page,
       locationListPage,
       mainLocationService,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
@@ -99,12 +97,7 @@ test.describe('Putaway item into hold bin', () => {
       await transactionListPage.table.deleteButton.click();
       await expect(transactionListPage.successMessage).toBeVisible();
 
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       await test.step('Deactivate created bin location', async () => {
         await BinLocationUtils.deactivateCreatedBin({

--- a/src/tests/putaway/putawayToPreferredBin.test.ts
+++ b/src/tests/putaway/putawayToPreferredBin.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { ProductResponse, StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -87,11 +87,9 @@ test.describe('Putaway to preferred bin and default bin', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       navbar,
       transactionListPage,
-      oldViewShipmentPage,
       productService,
       productShowPage,
       productEditPage,
@@ -100,12 +98,7 @@ test.describe('Putaway to preferred bin and default bin', () => {
       await navbar.transactions.click();
       await transactionListPage.deleteTransaction(1);
       await transactionListPage.deleteTransaction(1);
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
       const product2 = await productService.getProduct(Product.FOUR);
       await productShowPage.goToPage(product2.id);
       await productShowPage.editProductButton.click();

--- a/src/tests/putaway/qtyValidationsInPutaways.test.ts
+++ b/src/tests/putaway/qtyValidationsInPutaways.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -58,32 +58,20 @@ test.describe('Assert qty validations in putaways', () => {
     }
   );
 
-  test.afterEach(
-    async ({
-      putawayListPage,
-      stockMovementShowPage,
-      stockMovementService,
-      oldViewShipmentPage,
-    }) => {
-      // the received shipment must be cleaned up even when the test fails
-      // before the putaway is started
-      if (putawayOrderIdentifier) {
-        await putawayListPage.goToPage();
-        await putawayListPage.table
-          .rowByOrderNumber(`${putawayOrderIdentifier}`.toString().trim())
-          .actionsButton.click();
-        await putawayListPage.table.clickDeleteOrderButton(1);
-        await putawayListPage.emptyPutawayList.isVisible();
-      }
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+  test.afterEach(async ({ putawayListPage, stockMovementService }) => {
+    // the received shipment must be cleaned up even when the test fails
+    // before the putaway is started
+    if (putawayOrderIdentifier) {
+      await putawayListPage.goToPage();
+      await putawayListPage.table
+        .rowByOrderNumber(`${putawayOrderIdentifier}`.toString().trim())
+        .actionsButton.click();
+      await putawayListPage.table.clickDeleteOrderButton(1);
+      await putawayListPage.emptyPutawayList.isVisible();
     }
-  );
+
+    await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
+  });
 
   test('Assert qty validations in putaways', async ({
     stockMovementShowPage,

--- a/src/tests/putaway/rollbackLastReceiptWhenPutawayCreated.test.ts
+++ b/src/tests/putaway/rollbackLastReceiptWhenPutawayCreated.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -57,13 +57,7 @@ test.describe('Rollback last receipt behavior when putaway created', () => {
   );
 
   test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      navbar,
-      transactionListPage,
-      oldViewShipmentPage,
-    }) => {
+    async ({ stockMovementService, navbar, transactionListPage }) => {
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       await transactionListPage.table.row(1).actionsButton.click();
@@ -72,12 +66,7 @@ test.describe('Rollback last receipt behavior when putaway created', () => {
       await transactionListPage.table.row(1).actionsButton.click();
       await transactionListPage.table.deleteButton.click();
       await expect(transactionListPage.successMessage).toBeVisible();
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
     }
   );
 

--- a/src/tests/putaway/sortPutawayByCurrentPreferredAndOriginalOrder.test.ts
+++ b/src/tests/putaway/sortPutawayByCurrentPreferredAndOriginalOrder.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@/types';
 import { assignPreferredBin } from '@/utils/productUtils';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
-import { deleteReceivedShipment, receiveInbound } from '@/utils/shipmentUtils';
+import { deleteShipment, receiveInbound } from '@/utils/shipmentUtils';
 import { byNameAsc } from '@/utils/sortUtils';
 
 /**
@@ -88,9 +88,7 @@ test.describe('Sort putaway by current bin, preferred bin and original order', (
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
-      oldViewShipmentPage,
       navbar,
       transactionListPage,
       putawayListPage,
@@ -117,16 +115,12 @@ test.describe('Sort putaway by current bin, preferred bin and original order', (
       }
 
       if (inboundTwo) {
-        await deleteReceivedShipment({
-          stockMovementShowPage,
-          oldViewShipmentPage,
+        await deleteShipment({
           stockMovementService,
           STOCK_MOVEMENT: inboundTwo,
         });
       }
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
+      await deleteShipment({
         stockMovementService,
         STOCK_MOVEMENT: inboundOne,
       });

--- a/src/tests/putaway/splitLineInPutaway.test.ts
+++ b/src/tests/putaway/splitLineInPutaway.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -57,13 +57,7 @@ test.describe('Split line in Putaway', () => {
   );
 
   test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      navbar,
-      transactionListPage,
-      oldViewShipmentPage,
-    }) => {
+    async ({ stockMovementService, navbar, transactionListPage }) => {
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       await transactionListPage.table.row(1).actionsButton.click();
@@ -76,12 +70,7 @@ test.describe('Split line in Putaway', () => {
       await transactionListPage.table.deleteButton.click();
       await expect(transactionListPage.successMessage).toBeVisible();
 
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
     }
   );
 

--- a/src/tests/putaway/validationOnQtyRemovedFromReceivingBin.test.ts
+++ b/src/tests/putaway/validationOnQtyRemovedFromReceivingBin.test.ts
@@ -8,7 +8,7 @@ import ProductShowPage from '@/pages/product/productShow/ProductShowPage';
 import { ProductResponse, StockMovementResponse } from '@/types';
 import RefreshCachesUtils from '@/utils/RefreshCaches';
 import {
-  deleteReceivedShipment,
+  deleteShipment,
   getShipmentId,
   getShipmentItemId,
 } from '@/utils/shipmentUtils';
@@ -74,24 +74,13 @@ test.describe('Assert validation on qty removed from receiving bin', () => {
   );
 
   test.afterEach(
-    async ({
-      stockMovementShowPage,
-      stockMovementService,
-      navbar,
-      transactionListPage,
-      oldViewShipmentPage,
-    }) => {
+    async ({ stockMovementService, navbar, transactionListPage }) => {
       await navbar.configurationButton.click();
       await navbar.transactions.click();
       for (let n = 1; n < 6; n++) {
         await transactionListPage.deleteTransaction(1);
       }
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
     }
   );
 

--- a/src/tests/receiving/assertBinLocationField.test.ts
+++ b/src/tests/receiving/assertBinLocationField.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Assert bin location not clearable', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -40,22 +40,13 @@ test.describe('Assert bin location not clearable', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await BinLocationUtils.deactivateReceivingBin({

--- a/src/tests/receiving/assertCreationOfGoodsReceiptNote.test.ts
+++ b/src/tests/receiving/assertCreationOfGoodsReceiptNote.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { pageContainsValues } from '@/utils/pageUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 import { captureRowValues } from '@/utils/tableUtils';
 
 test.describe('Assert Goods Receipt Note is created and opened', () => {
@@ -41,22 +41,13 @@ test.describe('Assert Goods Receipt Note is created and opened', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await BinLocationUtils.deactivateReceivingBin({

--- a/src/tests/receiving/assertCreationOfReceivingBin.test.ts
+++ b/src/tests/receiving/assertCreationOfReceivingBin.test.ts
@@ -7,7 +7,7 @@ import CreateLocationPage from '@/pages/location/createLocation/CreateLocationPa
 import LocationListPage from '@/pages/location/LocationListPage';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Assert creation of receiving bin', () => {
   test.describe.configure({ timeout: 60000 });
@@ -47,22 +47,13 @@ test.describe('Assert creation of receiving bin', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/assertQtyInputs.test.ts
+++ b/src/tests/receiving/assertQtyInputs.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { formatDate, getDateByOffset } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Assert if quantity inputs remain when split lines', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -45,22 +45,13 @@ test.describe('Assert if quantity inputs remain when split lines', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/assertRecipientField.test.ts
+++ b/src/tests/receiving/assertRecipientField.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Assert recipient field when receive', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -48,22 +48,13 @@ test.describe('Assert recipient field when receive', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/cancelRemainingQty.test.ts
+++ b/src/tests/receiving/cancelRemainingQty.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Cancel qty in the middle of receipt', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -42,22 +42,13 @@ test.describe('Cancel qty in the middle of receipt', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await BinLocationUtils.deactivateReceivingBin({

--- a/src/tests/receiving/editBinLocationWhenReceive.test.ts
+++ b/src/tests/receiving/editBinLocationWhenReceive.test.ts
@@ -5,7 +5,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 test.describe('Edit Bin Location when receive inbound stock movement', () => {
@@ -69,25 +69,16 @@ test.describe('Edit Bin Location when receive inbound stock movement', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       page,
       locationListPage,
       mainLocationService,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
       const mainLocation = await mainLocationService.getLocation();
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       await test.step('Deactivate created bin location', async () => {
         await page.goto(LOCATION_URL.list());
@@ -266,25 +257,16 @@ test.describe('Edit Bin Location to bin with zone when receive inbound stock mov
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       page,
       locationListPage,
       mainLocationService,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
       const mainLocation = await mainLocationService.getLocation();
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       await test.step('Deactivate created bin location', async () => {
         await page.goto(LOCATION_URL.list());
@@ -465,25 +447,16 @@ test.describe('Edit Bin Location when receive for all lines', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       page,
       locationListPage,
       mainLocationService,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
       const mainLocation = await mainLocationService.getLocation();
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       await test.step('Deactivate created bin location', async () => {
         await page.goto(LOCATION_URL.list());

--- a/src/tests/receiving/editOriginalLineQtyTo0.test.ts
+++ b/src/tests/receiving/editOriginalLineQtyTo0.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getDateByOffset } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 test.describe('Edit qty of original line to 0', () => {
@@ -58,22 +58,13 @@ test.describe('Edit qty of original line to 0', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
@@ -253,22 +244,13 @@ test.describe('Edit original line to other product in the middle of receipt', ()
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await BinLocationUtils.deactivateReceivingBin({

--- a/src/tests/receiving/editsInReceiving.test.ts
+++ b/src/tests/receiving/editsInReceiving.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { formatDate, getDateByOffset, getToday } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 test.describe('Edit items in the middle of receipt', () => {
@@ -51,22 +51,13 @@ test.describe('Edit items in the middle of receipt', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/exportReceivingTemplate.test.ts
+++ b/src/tests/receiving/exportReceivingTemplate.test.ts
@@ -7,7 +7,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { formatDate, getDateByOffset } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 import { WorkbookUtils } from '@/utils/WorkbookUtils';
 
@@ -54,22 +54,13 @@ test.describe('Export receiving template', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       for (const workbook of workbooks) {
         workbook.delete();

--- a/src/tests/receiving/importReceivingTemplate.test.ts
+++ b/src/tests/receiving/importReceivingTemplate.test.ts
@@ -7,7 +7,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getDateByOffset } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 import { WorkbookUtils } from '@/utils/WorkbookUtils';
 
@@ -53,22 +53,13 @@ test.describe('Import receiving template', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       for (const workbook of workbooks) {
         workbook.delete();

--- a/src/tests/receiving/lotExpirySystemUpdateOnReceiving.test.ts
+++ b/src/tests/receiving/lotExpirySystemUpdateOnReceiving.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { formatDate, getDateByOffset, getToday } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 test.describe('Lot number system expiry date modification on receiving workflow', () => {
@@ -19,7 +19,6 @@ test.describe('Lot number system expiry date modification on receiving workflow'
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
       // TODO: Improve this one, it is prone to getting stuck if there are not deleted SMs in the tested location
       while (STOCK_MOVEMENTS.length > 0) {
@@ -32,12 +31,7 @@ test.describe('Lot number system expiry date modification on receiving workflow'
         });
 
         await test.step(`Delete stock movement "${STOCK_MOVEMENT.id}"`, async () => {
-          await deleteReceivedShipment({
-            stockMovementShowPage,
-            oldViewShipmentPage,
-            stockMovementService,
-            STOCK_MOVEMENT,
-          });
+          await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
         });
 
         const receivingBin =

--- a/src/tests/receiving/receiveInbound.test.ts
+++ b/src/tests/receiving/receiveInbound.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { formatDate, getToday } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Receive inbound stock movement', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -45,22 +45,13 @@ test.describe('Receive inbound stock movement', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
@@ -414,23 +405,10 @@ test.describe('Receive from different locations', () => {
     }
   );
 
-  test.afterEach(
-    async ({
-      authService,
-      stockMovementShowPage,
-      stockMovementService,
-      oldViewShipmentPage,
-    }) => {
-      await authService.changeLocation(AppConfig.instance.locations.main.id);
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
-    }
-  );
+  test.afterEach(async ({ authService, stockMovementService }) => {
+    await authService.changeLocation(AppConfig.instance.locations.main.id);
+    await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
+  });
 
   test('Receiving should not be available from other location than which is specfied as destination location', async ({
     stockMovementShowPage,

--- a/src/tests/receiving/receiveInboundWithoutPartialReceiving.test.ts
+++ b/src/tests/receiving/receiveInboundWithoutPartialReceiving.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import { formatDate, getToday } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Receive inbound stock movement in location without partial receiving', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -44,29 +44,16 @@ test.describe('Receive inbound stock movement in location without partial receiv
     }
   );
 
-  test.afterEach(
-    async ({
-      stockMovementShowPage,
-      authService,
-      oldViewShipmentPage,
-      stockMovementService,
-    }) => {
-      // the shipment must be deleted while the session is still at the depot,
-      // but the location has to be restored even when the cleanup fails,
-      // otherwise the next test file runs against the wrong location
-      try {
-        await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-        await deleteReceivedShipment({
-          stockMovementShowPage,
-          oldViewShipmentPage,
-          stockMovementService,
-          STOCK_MOVEMENT,
-        });
-      } finally {
-        await authService.changeLocation(AppConfig.instance.locations.main.id);
-      }
+  test.afterEach(async ({ authService, stockMovementService }) => {
+    // the shipment must be deleted while the session is still at the depot,
+    // but the location has to be restored even when the cleanup fails,
+    // otherwise the next test file runs against the wrong location
+    try {
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
+    } finally {
+      await authService.changeLocation(AppConfig.instance.locations.main.id);
     }
-  );
+  });
 
   test('Assert Confirm receiving dialog and select No, receive 1 item fully', async ({
     stockMovementShowPage,

--- a/src/tests/receiving/receiveInboundWithoutPickAndPutawayStock.test.ts
+++ b/src/tests/receiving/receiveInboundWithoutPickAndPutawayStock.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import { getToday } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Receive inbound stock movement in location without pick and putaway stock', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -41,29 +41,16 @@ test.describe('Receive inbound stock movement in location without pick and putaw
     }
   );
 
-  test.afterEach(
-    async ({
-      stockMovementShowPage,
-      authService,
-      oldViewShipmentPage,
-      stockMovementService,
-    }) => {
-      // the shipment must be deleted while the session is still at the depot,
-      // but the location has to be restored even when the cleanup fails,
-      // otherwise the next test file runs against the wrong location
-      try {
-        await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-        await deleteReceivedShipment({
-          stockMovementShowPage,
-          oldViewShipmentPage,
-          stockMovementService,
-          STOCK_MOVEMENT,
-        });
-      } finally {
-        await authService.changeLocation(AppConfig.instance.locations.main.id);
-      }
+  test.afterEach(async ({ authService, stockMovementService }) => {
+    // the shipment must be deleted while the session is still at the depot,
+    // but the location has to be restored even when the cleanup fails,
+    // otherwise the next test file runs against the wrong location
+    try {
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
+    } finally {
+      await authService.changeLocation(AppConfig.instance.locations.main.id);
     }
-  );
+  });
 
   test('Receive sm in location without pick and putaway stock', async ({
     stockMovementShowPage,

--- a/src/tests/receiving/receiveToHoldBin.test.ts
+++ b/src/tests/receiving/receiveToHoldBin.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 test.describe('Receive item into hold bin', () => {
@@ -54,23 +54,15 @@ test.describe('Receive item into hold bin', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       page,
       locationListPage,
       mainLocationService,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       await test.step('Deactivate created bin location', async () => {
         await BinLocationUtils.deactivateCreatedBin({

--- a/src/tests/receiving/receivingStatusChanges.test.ts
+++ b/src/tests/receiving/receivingStatusChanges.test.ts
@@ -7,7 +7,7 @@ import StockMovementShowPage from '@/pages/stockMovementShow/StockMovementShowPa
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getToday } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Status changes on sm view page when receive shipment', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -46,21 +46,13 @@ test.describe('Status changes on sm view page when receive shipment', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await BinLocationUtils.deactivateReceivingBin({

--- a/src/tests/receiving/receivingStatusChangesWithoutPartialReceiving.test.ts
+++ b/src/tests/receiving/receivingStatusChangesWithoutPartialReceiving.test.ts
@@ -6,7 +6,7 @@ import InboundListPage from '@/pages/inbound/list/InboundListPage';
 import StockMovementShowPage from '@/pages/stockMovementShow/StockMovementShowPage';
 import { StockMovementResponse } from '@/types';
 import { getToday } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Status changes on sm view page when receive shipment in location without partial receiving', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -46,24 +46,11 @@ test.describe('Status changes on sm view page when receive shipment in location 
     }
   );
 
-  test.afterEach(
-    async ({
-      stockMovementShowPage,
-      authService,
-      oldViewShipmentPage,
-      stockMovementService,
-    }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+  test.afterEach(async ({ authService, stockMovementService }) => {
+    await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
-      await authService.changeLocation(AppConfig.instance.locations.main.id);
-    }
-  );
+    await authService.changeLocation(AppConfig.instance.locations.main.id);
+  });
 
   test('Assert status changes on view page and receipt tab when receive 1 item partially', async ({
     stockMovementShowPage,

--- a/src/tests/receiving/rollbackStatusChanges.test.ts
+++ b/src/tests/receiving/rollbackStatusChanges.test.ts
@@ -7,7 +7,7 @@ import StockMovementShowPage from '@/pages/stockMovementShow/StockMovementShowPa
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getToday } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Status changes on sm view page when rollback receipts', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -46,21 +46,13 @@ test.describe('Status changes on sm view page when rollback receipts', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/sortByAlphabeticalOrderAndRemainInputs.test.ts
+++ b/src/tests/receiving/sortByAlphabeticalOrderAndRemainInputs.test.ts
@@ -4,7 +4,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getDateByOffset, getToday } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Apply sorting by alphabetical order and remain inputs', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -38,21 +38,13 @@ test.describe('Apply sorting by alphabetical order and remain inputs', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/tableShortcutsInReceiving.test.ts
+++ b/src/tests/receiving/tableShortcutsInReceiving.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@/fixtures/fixtures';
 import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Use table shortcuts on receiving page', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -59,21 +59,13 @@ test.describe('Use table shortcuts on receiving page', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/tests/receiving/validationsOnDeliverOnDate.test.ts
+++ b/src/tests/receiving/validationsOnDeliverOnDate.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { formatDate, getDateByOffset } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Validations on edit Deliver On Date when receiving shipment', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -36,21 +36,13 @@ test.describe('Validations on edit Deliver On Date when receiving shipment', () 
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;
       await BinLocationUtils.deactivateReceivingBin({

--- a/src/tests/receiving/validationsOnEditAndReceive.test.ts
+++ b/src/tests/receiving/validationsOnEditAndReceive.test.ts
@@ -5,7 +5,7 @@ import { Product } from '@/generated/ProductCodes.generated';
 import { StockMovementResponse } from '@/types';
 import BinLocationUtils from '@/utils/BinLocationUtils';
 import { getToday } from '@/utils/DateUtils';
-import { deleteReceivedShipment } from '@/utils/shipmentUtils';
+import { deleteShipment } from '@/utils/shipmentUtils';
 
 test.describe('Assert validation on try to receive not yet shipped inbound', () => {
   let STOCK_MOVEMENT: StockMovementResponse;
@@ -38,9 +38,8 @@ test.describe('Assert validation on try to receive not yet shipped inbound', () 
     }
   );
 
-  test.afterEach(async ({ stockMovementShowPage, stockMovementService }) => {
-    await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-    await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
+  test.afterEach(async ({ stockMovementService }) => {
+    await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
   });
 
   test('Assert validation on try to receive not yet shipped inbound', async ({
@@ -99,21 +98,13 @@ test.describe('Validations on edit and receive inbound stock movement', () => {
 
   test.afterEach(
     async ({
-      stockMovementShowPage,
       stockMovementService,
       mainLocationService,
       page,
       locationListPage,
       createLocationPage,
-      oldViewShipmentPage,
     }) => {
-      await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-      await deleteReceivedShipment({
-        stockMovementShowPage,
-        oldViewShipmentPage,
-        stockMovementService,
-        STOCK_MOVEMENT,
-      });
+      await deleteShipment({ stockMovementService, STOCK_MOVEMENT });
 
       const receivingBin =
         AppConfig.instance.receivingBinPrefix + STOCK_MOVEMENT.identifier;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -222,6 +222,7 @@ type StockMovementResponse = {
   associations: {
     shipment: {
       id: string;
+      status: string;
     };
   };
 };

--- a/src/utils/shipmentUtils.ts
+++ b/src/utils/shipmentUtils.ts
@@ -71,7 +71,10 @@ export async function deleteShipment({
   STOCK_MOVEMENT: StockMovementResponse;
   stockMovementService: StockMovementService;
 }) {
-  await stockMovementService.rollbackShipmentToPending(STOCK_MOVEMENT.id);
+  await stockMovementService.rollbackShipmentToStatus(
+    STOCK_MOVEMENT.id,
+    'PENDING'
+  );
   await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
 
   // The server clears receiving-bin stock asynchronously after the stock

--- a/src/utils/shipmentUtils.ts
+++ b/src/utils/shipmentUtils.ts
@@ -5,8 +5,6 @@ import ReceivingService from '@/api/ReceivingService';
 import StockMovementService from '@/api/StockMovementService';
 import AppConfig from '@/config/AppConfig';
 import { ShipmentType } from '@/constants/ShipmentType';
-import OldViewShipmentPage from '@/pages/stockMovementShow/OldViewShipmentPage';
-import StockMovementShowPage from '@/pages/stockMovementShow/StockMovementShowPage';
 import { ReceiptResponse, StockMovementResponse } from '@/types';
 
 export const getShipmentId = (stockMovement: StockMovementResponse) => {
@@ -62,22 +60,18 @@ export async function receiveInbound(
   await receivingService.completeReceipt(shipmentId);
 }
 
-export async function deleteReceivedShipment({
-  stockMovementShowPage,
-  oldViewShipmentPage,
+/**
+  Deletes a stock movement through the API regardless of the shipment status,
+  rolling back the received and shipped events first when needed.
+*/
+export async function deleteShipment({
   stockMovementService,
   STOCK_MOVEMENT,
 }: {
   STOCK_MOVEMENT: StockMovementResponse;
   stockMovementService: StockMovementService;
-  stockMovementShowPage: StockMovementShowPage;
-  oldViewShipmentPage: OldViewShipmentPage;
 }) {
-  await stockMovementShowPage.goToPage(STOCK_MOVEMENT.id);
-  await stockMovementShowPage.detailsListTable.oldViewShipmentPage.click();
-  await oldViewShipmentPage.undoStatusChangeButton.click();
-  await stockMovementShowPage.isLoaded();
-  await stockMovementShowPage.rollbackButton.click();
+  await stockMovementService.rollbackShipmentToPending(STOCK_MOVEMENT.id);
   await stockMovementService.deleteStockMovement(STOCK_MOVEMENT.id);
 
   // The server clears receiving-bin stock asynchronously after the stock


### PR DESCRIPTION
refactored delete shipment method so sm are now deleted through api no by ui to save time of execution, updated receiving and putaway tests 